### PR TITLE
[#8] 리뷰 등록 API 구현

### DIFF
--- a/src/main/java/com/example/locavel/LocavelApplication.java
+++ b/src/main/java/com/example/locavel/LocavelApplication.java
@@ -2,8 +2,10 @@ package com.example.locavel;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class LocavelApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/locavel/converter/ReviewConverter.java
+++ b/src/main/java/com/example/locavel/converter/ReviewConverter.java
@@ -1,0 +1,30 @@
+package com.example.locavel.converter;
+
+import com.example.locavel.domain.Places;
+import com.example.locavel.domain.Reviews;
+import com.example.locavel.domain.User;
+import com.example.locavel.domain.enums.Traveler;
+import com.example.locavel.web.dto.ReviewDTO.ReviewRequestDTO;
+import com.example.locavel.web.dto.ReviewDTO.ReviewResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class ReviewConverter {
+    public static ReviewResponseDTO.ReviewResultDTO toReviewResultDTO(Reviews review) {
+        return ReviewResponseDTO.ReviewResultDTO.builder()
+                .reviewId(review.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+    public static Reviews toReviews(User user, Traveler traveler, Places place, ReviewRequestDTO.RevieweDTO request) {
+        return Reviews.builder()
+                .comment(request.getComment())
+                //TODO : S3 추가 시 url로 변경
+//                .reviewImg(null)
+                .user(user)
+                .traveler(traveler)
+                .place(place)
+                .rating(request.getRating())
+                .build();
+    }
+}

--- a/src/main/java/com/example/locavel/domain/Reviews.java
+++ b/src/main/java/com/example/locavel/domain/Reviews.java
@@ -26,8 +26,9 @@ public class Reviews extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_id")
     private Places place;
-
-    private String img;
+    @ElementCollection
+    @CollectionTable(name = "review_img", joinColumns = @JoinColumn(name = "reviews_id"))
+    private List<String> reviewImg;
 
     private String comment;
 

--- a/src/main/java/com/example/locavel/domain/Reviews.java
+++ b/src/main/java/com/example/locavel/domain/Reviews.java
@@ -3,9 +3,10 @@ package com.example.locavel.domain;
 import com.example.locavel.domain.common.BaseEntity;
 import com.example.locavel.domain.enums.Traveler;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -32,9 +33,11 @@ public class Reviews extends BaseEntity {
 
     private String comment;
 
-    private Traveler traveler;//Role로 수정 가능성
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Traveler traveler;
 
+    @NotNull
     private Float rating;
 
-    private LocalDateTime created_at;
 }

--- a/src/main/java/com/example/locavel/domain/enums/Traveler.java
+++ b/src/main/java/com/example/locavel/domain/enums/Traveler.java
@@ -1,7 +1,28 @@
 package com.example.locavel.domain.enums;
 
-public enum Traveler {
+import com.example.locavel.domain.Places;
+import com.example.locavel.domain.User;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
 
-    YES,
-    NO
+@AllArgsConstructor
+public enum Traveler {
+    YES("여행자"),
+    NO("현지인");
+
+    private final String viewName;
+
+    // 유저의 현지인/여행자 판단
+    public static Traveler of(Places place, User user) {
+        String location = user.getLocation();
+        String placeAddress = place.getRegion().getAddress();
+        if (placeAddress.contains(location)) {
+            return NO;
+        }
+        else return YES;
+    }
+    @JsonValue
+    public String getViewName() {
+        return viewName;
+    }
 }

--- a/src/main/java/com/example/locavel/repository/PlaceRepository.java
+++ b/src/main/java/com/example/locavel/repository/PlaceRepository.java
@@ -1,0 +1,7 @@
+package com.example.locavel.repository;
+
+import com.example.locavel.domain.Places;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceRepository extends JpaRepository<Places, Long> {
+}

--- a/src/main/java/com/example/locavel/repository/ReviewRepository.java
+++ b/src/main/java/com/example/locavel/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.example.locavel.repository;
+
+import com.example.locavel.domain.Reviews;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Reviews, Long> {
+}

--- a/src/main/java/com/example/locavel/repository/UserRepository.java
+++ b/src/main/java/com/example/locavel/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.example.locavel.repository;
+
+import com.example.locavel.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/locavel/service/ReviewService.java
+++ b/src/main/java/com/example/locavel/service/ReviewService.java
@@ -1,0 +1,33 @@
+package com.example.locavel.service;
+
+import com.example.locavel.converter.ReviewConverter;
+import com.example.locavel.domain.Places;
+import com.example.locavel.domain.Reviews;
+import com.example.locavel.domain.User;
+import com.example.locavel.domain.enums.Traveler;
+import com.example.locavel.repository.PlaceRepository;
+import com.example.locavel.repository.ReviewRepository;
+import com.example.locavel.repository.UserRepository;
+import com.example.locavel.web.dto.ReviewDTO.ReviewRequestDTO;
+import com.example.locavel.web.dto.ReviewDTO.ReviewResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+    private final PlaceRepository placeRepository;
+    public ReviewResponseDTO.ReviewResultDTO createReview(Long placeId, ReviewRequestDTO.RevieweDTO request) {
+        //TODO : JWT 토큰 추가 후 변경
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(()->new RuntimeException("해당하는 유저가 없습니다."));
+        Places place = placeRepository.findById(placeId)
+                .orElseThrow(()->new RuntimeException("해당하는 장소가 없습니다."));
+        Traveler traveler = Traveler.of(place, user);
+        Reviews review = ReviewConverter.toReviews(user, traveler, place, request);
+        Reviews savedReview = reviewRepository.save(review);
+        return ReviewConverter.toReviewResultDTO(savedReview);
+    }
+}

--- a/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
@@ -1,0 +1,27 @@
+package com.example.locavel.web.controller;
+
+import com.example.locavel.apiPayload.ApiResponse;
+import com.example.locavel.service.ReviewService;
+import com.example.locavel.web.dto.ReviewDTO.ReviewRequestDTO;
+import com.example.locavel.web.dto.ReviewDTO.ReviewResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews")
+public class ReviewRestController {
+    private final ReviewService reviewService;
+
+    @Operation(summary = "리뷰 등록", description = "리뷰를 등록합니다.")
+    @PostMapping(consumes = "multipart/form-data")
+    public ApiResponse<ReviewResponseDTO.ReviewResultDTO> createReview(
+            @Valid @RequestBody ReviewRequestDTO.RevieweDTO request,
+            @RequestParam Long placeId) {
+        ReviewResponseDTO.ReviewResultDTO response = reviewService.createReview(placeId, request);
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
@@ -17,10 +17,10 @@ public class ReviewRestController {
     private final ReviewService reviewService;
 
     @Operation(summary = "리뷰 등록", description = "리뷰를 등록합니다.")
-    @PostMapping(consumes = "multipart/form-data")
+    @PostMapping(value = "/{placeId}", consumes = "multipart/form-data")
     public ApiResponse<ReviewResponseDTO.ReviewResultDTO> createReview(
             @Valid @RequestBody ReviewRequestDTO.RevieweDTO request,
-            @RequestParam Long placeId) {
+            @PathVariable(name="placeId") Long placeId) {
         ReviewResponseDTO.ReviewResultDTO response = reviewService.createReview(placeId, request);
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewRequestDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewRequestDTO.java
@@ -1,0 +1,19 @@
+package com.example.locavel.web.dto.ReviewDTO;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+public class ReviewRequestDTO {
+    @Getter
+    @Setter
+    public static class RevieweDTO {
+        //TODO :  JWT 토큰 추가 후 userId 삭제
+        Long userId;
+        //TODO : S3 추가 후 수정
+//        List<MultipartFile> reviewImgList;
+        String comment;
+        @NotNull
+        Float rating;
+    }
+}

--- a/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewResponseDTO.java
@@ -1,0 +1,19 @@
+package com.example.locavel.web.dto.ReviewDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class ReviewResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewResultDTO {
+        Long reviewId;
+        LocalDateTime createdAt;
+    }
+}


### PR DESCRIPTION
### 📌 관련 이슈
#8 

### 💻 작업 내용
- 리뷰 등록 API를 구현했습니다. 
- 리뷰에 사진을 여러장 등록할 수 있도록 수정했습니다. 다만, 아직 S3가 연동되지 않아 리뷰의 사진을 등록하는 부분은 구현하지 않았습니다!
- 리뷰를 작성한 유저의 인증 위치에 따라 여행자/현지인 구분이 자동으로 판단될 수 있도록 구현했습니다.
- BaseEntity 사용을 위해 @EnableJpaAuditing를 추가했습니다.
- 현재는 userId를 직접 입력받고 있으나, JWT 토큰이 구현되면 수정할 예정입니다.