### PR TITLE
[#20] 리뷰 수정 API 구현

### DIFF
--- a/src/main/java/com/example/locavel/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/locavel/apiPayload/code/status/ErrorStatus.java
@@ -26,6 +26,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //리뷰
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND,"REVIEW4001", "리뷰가 없습니다."),
     RATING_NOT_EXIST(HttpStatus.BAD_REQUEST, "REVIEW4002","총점은 필수 입니다."),
+    RATING_NOT_VALID(HttpStatus.BAD_REQUEST,"REVIEW4003", "총점은 0~5점이어야 합니다."),
 
     //장소
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE4001", "장소가 없습니다."),;

--- a/src/main/java/com/example/locavel/converter/ReviewConverter.java
+++ b/src/main/java/com/example/locavel/converter/ReviewConverter.java
@@ -32,4 +32,10 @@ public class ReviewConverter {
                 .imgUrl(url)
                 .build();
     }
+    public static ReviewResponseDTO.ReviewUpdateResultDTO toReviewUpdateResultDTO(Reviews review) {
+        return ReviewResponseDTO.ReviewUpdateResultDTO.builder()
+                .reviewId(review.getId())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/com/example/locavel/service/ReviewService.java
+++ b/src/main/java/com/example/locavel/service/ReviewService.java
@@ -43,6 +43,15 @@ public class ReviewService {
         return ReviewConverter.toReviewResultDTO(savedReview);
     }
 
+    public ReviewResponseDTO.ReviewUpdateResultDTO updateReview(Long reviewId, ReviewRequestDTO.RevieweDTO request, List<MultipartFile> reviewImgUrls) {
+        Reviews review = reviewRepository.findById(reviewId)
+                .orElseThrow(()->new ReviewsHandler(ErrorStatus.REVIEW_NOT_FOUND));
+        if(request.getRating() != null) {review.setRating(request.getRating());}
+        if(request.getComment() != null) {review.setComment(request.getComment());}
+        if(reviewImgUrls != null) {uploadReviewImg(reviewImgUrls, review, true);}
+        Reviews updatedReview = reviewRepository.save(review);
+        return ReviewConverter.toReviewUpdateResultDTO(updatedReview);
+    }
     public void uploadReviewImg(List<MultipartFile> reviewImg, Reviews reviews, boolean update) {
         if (update) {
             List<ReviewImg> reviewImgList = reviewImgRepository.findAllByReviews(reviews);

--- a/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
@@ -29,7 +29,23 @@ public class ReviewRestController {
         if(request.getRating() == null) {
             throw new ReviewsHandler(ErrorStatus.RATING_NOT_EXIST);
         }
+        if(request.getRating() > 5 || request.getRating() <0) {
+            throw new ReviewsHandler(ErrorStatus.RATING_NOT_VALID);
+        }
         ReviewResponseDTO.ReviewResultDTO response = reviewService.createReview(placeId, request, reviewImgUrls);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "리뷰 수정", description = "리뷰를 수정합니다.")
+    @PatchMapping(value = "/{reviewId}", consumes = "multipart/form-data")
+    public ApiResponse<ReviewResponseDTO.ReviewUpdateResultDTO> updateReview(
+            @Valid @RequestPart ReviewRequestDTO.RevieweDTO request,
+            @PathVariable(name="reviewId") Long reviewId,
+            @RequestPart(required = false) List<MultipartFile> reviewImgUrls) {
+        if(request.getRating() > 5 || request.getRating() <0) {
+            throw new ReviewsHandler(ErrorStatus.RATING_NOT_VALID);
+        }
+        ReviewResponseDTO.ReviewUpdateResultDTO response = reviewService.updateReview(reviewId, request, reviewImgUrls);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewResponseDTO.java
@@ -16,4 +16,12 @@ public class ReviewResponseDTO {
         Long reviewId;
         LocalDateTime createdAt;
     }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewUpdateResultDTO {
+        Long reviewId;
+        LocalDateTime updatedAt;
+    }
 }


### PR DESCRIPTION
### 💻 작업 내용
- 리뷰 수정 API를 구현했습니다.
- PATCH 메서드를 이용하여 수정할 내용만 요청받아 수정합니다.
- 만약 리뷰 이미지를 수정할 경우, 새로 수정한 이미지만 남겨두고 기존 이미지는 s3, 데이터베이스 모두에서 삭제합니다.
-  리뷰수정 성공 시, 수정한 리뷰 id와 수정한 날짜,시간이 응답에 포함됩니다.