### PR TITLE
[#24] 리뷰 목록 조회 및 리뷰 요약 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/example/locavel/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/locavel/apiPayload/code/status/ErrorStatus.java
@@ -33,6 +33,8 @@ public enum ErrorStatus implements BaseErrorCode {
     PLACE_NOT_EXIST(HttpStatus.BAD_REQUEST, "PLACE4002", "장소명은 필수입니다."),
     PLACE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "PLACE4003", "이미 등록된 장소입니다."),
 
+    //페이지
+    PAGE_NOT_VALID(HttpStatus.BAD_REQUEST,"PAGE4001", "페이지는 1 이상이어야 합니다."),
 
     ;
 

--- a/src/main/java/com/example/locavel/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/locavel/apiPayload/code/status/SuccessStatus.java
@@ -12,9 +12,14 @@ public enum SuccessStatus implements BaseCode {
 
     //일반적인 응답
     _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+
+    //리뷰
     REVIEW_CREATE_OK(HttpStatus.OK,"REVIEW2001", "리뷰가 정상적으로 등록되었습니다."),
     REVIEW_UPDATE_OK(HttpStatus.OK,"REVIEW2002", "리뷰가 정상적으로 수정되었습니다."),
-    REVIEW_DELETE_OK(HttpStatus.OK,"REVIEW2003", "리뷰가 정상적으로 삭제되었습니다."),;
+    REVIEW_DELETE_OK(HttpStatus.OK,"REVIEW2003", "리뷰가 정상적으로 삭제되었습니다."),
+    REVIEW_GET_OK(HttpStatus.OK,"REVIEW2004","리뷰 목록을 조회했습니다."),
+    REVIEW_SUMMARY_GET_OK(HttpStatus.OK,"REVIEW2005", "리뷰 요약을 조회했습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/locavel/converter/ReviewConverter.java
+++ b/src/main/java/com/example/locavel/converter/ReviewConverter.java
@@ -5,11 +5,20 @@ import com.example.locavel.domain.ReviewImg;
 import com.example.locavel.domain.Reviews;
 import com.example.locavel.domain.User;
 import com.example.locavel.domain.enums.Traveler;
+import com.example.locavel.repository.ReviewImgRepository;
 import com.example.locavel.web.dto.ReviewDTO.ReviewRequestDTO;
 import com.example.locavel.web.dto.ReviewDTO.ReviewResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
+@RequiredArgsConstructor
+@Component
 public class ReviewConverter {
     public static ReviewResponseDTO.ReviewResultDTO toReviewResultDTO(Reviews review) {
         return ReviewResponseDTO.ReviewResultDTO.builder()
@@ -37,5 +46,93 @@ public class ReviewConverter {
                 .reviewId(review.getId())
                 .updatedAt(LocalDateTime.now())
                 .build();
+    }
+    public static ReviewResponseDTO.ReviewPreviewDTO toReviewPreviewDTO(
+            Reviews review, List<String> reviewImgList) {
+        User user = review.getUser();
+        return ReviewResponseDTO.ReviewPreviewDTO.builder()
+                .reviewId(review.getId())
+                .reviewerImg(user.getProfileImage())
+                .reviewerName(user.getNickname())
+                .traveler(Traveler.of(review.getPlace(),user).getViewName())
+                .reviewImgList(reviewImgList)
+                .Rating(review.getRating())
+                .comment(review.getComment())
+                .createdAt(review.getCreated_at())
+                .updatedAt(review.getUpdated_at())
+                .build();
+    }
+    public ReviewResponseDTO.ReviewPreviewListDTO toReviewPreviewListDTO(Page<Reviews> reviewList) {
+        List<ReviewResponseDTO.ReviewPreviewDTO> reviewPreViewDTOList = reviewList.stream()
+                .map(review -> {
+                    List<String> reviewImgList = getAllReviewImgUrls(review);
+                    return toReviewPreviewDTO(review,reviewImgList);
+                }).collect(Collectors.toList());
+        return ReviewResponseDTO.ReviewPreviewListDTO.builder()
+                .reviewList(reviewPreViewDTOList)
+                .listSize(reviewList.getSize())
+                .isFirst(reviewList.isFirst())
+                .isLast(reviewList.isLast())
+                .totalElements(reviewList.getTotalElements())
+                .totalPage(reviewList.getTotalPages())
+                .build();
+    }
+
+    public static ReviewResponseDTO.MyReviewDTO toMyReviewDTO(
+            Reviews review, List<String> reviewImgList) {
+        Places place = review.getPlace();
+        return ReviewResponseDTO.MyReviewDTO.builder()
+                .reviewId(review.getId())
+                .reviewImgList(reviewImgList)
+                .address(place.getAddress())
+                .placeName(place.getName())
+                .createdAt(review.getCreated_at())
+                .updatedAt(review.getUpdated_at())
+                .comment(review.getComment())
+                .Rating(review.getRating())
+                .build();
+    }
+
+    public ReviewResponseDTO.MyReviewListDTO toMyReviewListDTO(Page<Reviews> reviewList) {
+        List<ReviewResponseDTO.MyReviewDTO> myReviewDTOList = reviewList.stream()
+                .map(review ->{
+                    List<String> reviewImgList = getAllReviewImgUrls(review);
+                    return toMyReviewDTO(review,reviewImgList);
+                }).collect(Collectors.toList());
+        return ReviewResponseDTO.MyReviewListDTO.builder()
+                .isFirst(reviewList.isFirst())
+                .isLast(reviewList.isLast())
+                .listSize(reviewList.getSize())
+                .reviewList(myReviewDTOList)
+                .totalElements(reviewList.getTotalElements())
+                .totalPage(reviewList.getTotalPages())
+                .build();
+    }
+
+    public static ReviewResponseDTO.placeReviewSummaryDTO toPlaceReviewSummaryDTO(
+            Float totalRating,
+            Long totalReviewCount,
+            Float generalRating,
+            Long generalReviewCount,
+            Float travelerRating,
+            Long travelerReviewCount) {
+        return ReviewResponseDTO.placeReviewSummaryDTO.builder()
+                .totalRating(totalRating)
+                .totalReviewCount(totalReviewCount)
+                .generalRating(generalRating)
+                .generalReviewCount(generalReviewCount)
+                .travelerRating(travelerRating)
+                .travelerReviewCount(travelerReviewCount)
+                .build();
+    }
+
+    private final ReviewImgRepository reviewImgRepository;
+    public List<String> getAllReviewImgUrls(Reviews review) {
+        List<ReviewImg> reviewImgList = reviewImgRepository.findAllByReviews(review);
+        List<String> reviewImgUrlList = new ArrayList<>();
+        for(ReviewImg reviewImg : reviewImgList) {
+            reviewImgUrlList.add(reviewImg.getImgUrl());
+        }
+        return reviewImgUrlList;
     }
 }

--- a/src/main/java/com/example/locavel/domain/enums/Traveler.java
+++ b/src/main/java/com/example/locavel/domain/enums/Traveler.java
@@ -2,20 +2,23 @@ package com.example.locavel.domain.enums;
 
 import com.example.locavel.domain.Places;
 import com.example.locavel.domain.User;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum Traveler {
-    YES("여행자"),
+    YES("여행객"),
     NO("현지인");
 
     private final String viewName;
 
-    // 유저의 현지인/여행자 판단
+    // 유저의 현지인/여행객 판단
     public static Traveler of(Places place, User user) {
         String location = user.getLocation();
         String placeAddress = place.getRegion().getAddress();
+        System.out.println("location = " + location);
+        System.out.println("placeAddress = " + placeAddress);
         if (placeAddress.contains(location)) {
             return NO;
         }
@@ -24,5 +27,19 @@ public enum Traveler {
     @JsonValue
     public String getViewName() {
         return viewName;
+    }
+    @JsonCreator
+    public static Traveler toTraveler(String value) {
+        if (value == null) {
+            return null;
+        }
+        else {
+            for (Traveler traveler : Traveler.values()) {
+                if (traveler.viewName.equals(value)) {
+                    return traveler;
+                }
+            }
+            throw new IllegalArgumentException("Invalid traveler: " + value);
+        }
     }
 }

--- a/src/main/java/com/example/locavel/repository/ReviewRepository.java
+++ b/src/main/java/com/example/locavel/repository/ReviewRepository.java
@@ -1,7 +1,24 @@
 package com.example.locavel.repository;
 
+import com.example.locavel.domain.Places;
 import com.example.locavel.domain.Reviews;
+import com.example.locavel.domain.User;
+import com.example.locavel.domain.enums.Traveler;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface ReviewRepository extends JpaRepository<Reviews, Long> {
+public interface ReviewRepository extends JpaRepository<Reviews, Long>, JpaSpecificationExecutor<Reviews> {
+    Page<Reviews> findAllByUser(User user, PageRequest pageRequest);
+    Long countAllByPlaceAndTraveler(Places place, Traveler traveler);
+    Long countAllByPlace(Places place);
+
+    @Query("select avg(r.rating) from Reviews r where r.place.id = :placeId")
+    Float getAvgRatingByPlace(@Param("placeId")Long placeId);
+
+    @Query("select avg(r.rating) from Reviews r where r.place.id = :placeId and r.traveler = :traveler")
+    Float getAvgRatingByPlaceAndTraveler(@Param("placeId")Long placeId, @Param("traveler")Traveler traveler);
 }

--- a/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
@@ -4,12 +4,18 @@ import com.example.locavel.apiPayload.ApiResponse;
 import com.example.locavel.apiPayload.code.status.ErrorStatus;
 import com.example.locavel.apiPayload.code.status.SuccessStatus;
 import com.example.locavel.apiPayload.exception.handler.ReviewsHandler;
+import com.example.locavel.converter.ReviewConverter;
+import com.example.locavel.domain.Reviews;
+import com.example.locavel.domain.enums.Traveler;
 import com.example.locavel.service.ReviewService;
 import com.example.locavel.web.dto.ReviewDTO.ReviewRequestDTO;
 import com.example.locavel.web.dto.ReviewDTO.ReviewResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,6 +26,7 @@ import java.util.List;
 @RequestMapping("/api/reviews")
 public class ReviewRestController {
     private final ReviewService reviewService;
+    private final ReviewConverter reviewConverter;
 
     @Operation(summary = "리뷰 등록", description = "리뷰를 등록합니다.")
     @PostMapping(value = "/{placeId}", consumes = "multipart/form-data")
@@ -55,5 +62,46 @@ public class ReviewRestController {
     public ApiResponse<ReviewResponseDTO.ReviewResultDTO> deleteReview(@PathVariable(name="reviewId")Long reviewId) {
         ReviewResponseDTO.ReviewResultDTO response = reviewService.deleteReview(reviewId);
         return ApiResponse.of(SuccessStatus.REVIEW_DELETE_OK,response);
+    }
+
+    @Operation(summary = "리뷰 목록 조회", description = "특정 장소의 리뷰 목록을 조회합니다.")
+    @GetMapping(value="/places/{placeId}")
+    @Parameters({
+            @Parameter(name = "page", description = "페이지 번호, 1번이 1 페이지"),
+            @Parameter(name = "sort", description = "최신순/오래된순 중 입력해주세요. 기본은 최신순입니다."),
+            @Parameter(name = "filter", description = "여행객/현지인 중 입력해주세요. 입력하지 않으면 전체 조회입니다.")
+    })
+    public ApiResponse<ReviewResponseDTO.ReviewPreviewListDTO> getReviews(
+            @PathVariable(name="placeId")Long placeId,
+            @RequestParam(name = "page") Integer page,
+            @RequestParam(required = false, name = "sort") String sortOption,
+            @RequestParam(required = false, name = "filter") String travelerOption) {
+        if(page<=0){
+            throw new ReviewsHandler(ErrorStatus.PAGE_NOT_VALID);
+        }
+        Traveler traveler = Traveler.toTraveler(travelerOption);
+        Page<Reviews> reviewList= reviewService.getReviewList(placeId,page-1,sortOption,traveler);
+        ReviewResponseDTO.ReviewPreviewListDTO response = reviewConverter.toReviewPreviewListDTO(reviewList);
+        return ApiResponse.of(SuccessStatus.REVIEW_GET_OK,response);
+    }
+
+    @Operation(summary = "유저 리뷰 목록 조회", description = "특정 유저가 작성한 리뷰 목록을 조회합니다.")
+    @GetMapping(value = "/users/{userId}")
+    public ApiResponse<ReviewResponseDTO.MyReviewListDTO> getMyReviews(
+            @PathVariable(name="userId")Long userId,
+            @RequestParam(name = "page") Integer page) {
+        if(page<=0){
+            throw new ReviewsHandler(ErrorStatus.PAGE_NOT_VALID);
+        }
+        Page<Reviews> myReviewList = reviewService.getMyReviewList(userId,page-1);
+        ReviewResponseDTO.MyReviewListDTO response = reviewConverter.toMyReviewListDTO(myReviewList);
+        return ApiResponse.of(SuccessStatus.REVIEW_GET_OK,response);
+    }
+
+    @Operation(summary = "리뷰 요약 조회", description = "특정 장소의 리뷰 요약 정보를 조회합니다.")
+    @GetMapping(value = "/summary/{placeId}")
+    public ApiResponse<ReviewResponseDTO.placeReviewSummaryDTO> getReviewSummary(@PathVariable(name="placeId")Long placeId) {
+        ReviewResponseDTO.placeReviewSummaryDTO response = reviewService.getPlaceReviewSummary(placeId);
+        return ApiResponse.of(SuccessStatus.REVIEW_SUMMARY_GET_OK,response);
     }
 }

--- a/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ReviewResponseDTO {
     @Builder
@@ -23,5 +24,74 @@ public class ReviewResponseDTO {
     public static class ReviewUpdateResultDTO {
         Long reviewId;
         LocalDateTime updatedAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewPreviewListDTO {
+        List<ReviewPreviewDTO> reviewList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewPreviewDTO {
+        Long reviewId;
+        String traveler;
+        String reviewerName;
+        String reviewerImg;
+        List<String> reviewImgList;
+        String comment;
+        Float Rating;
+        LocalDateTime createdAt;
+        LocalDateTime updatedAt;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyReviewListDTO {
+        List<MyReviewDTO> reviewList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyReviewDTO {
+        Long reviewId;
+        String placeName;
+        String address;
+        List<String> reviewImgList;
+        String comment;
+        Float Rating;
+        LocalDateTime createdAt;
+        LocalDateTime updatedAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class placeReviewSummaryDTO {
+        Float totalRating;
+        Long totalReviewCount;
+        Float generalRating;
+        Long generalReviewCount;
+        Float travelerRating;
+        Long travelerReviewCount;
     }
 }


### PR DESCRIPTION
### 💻 작업 내용
- **장소별 리뷰 목록 조회 API**를 구현했습니다. 여행객/현지인 필터, 최신순/오래된순 정렬이 가능합니다. 정렬 기본은 최신순입니다. 
- **유저가 작성한 리뷰 목록 조회 API**를 구현했습니다. 
- **장소별 리뷰 요약 정보 조회 API**를 구현했습니다. 총 리뷰 개수, 총 리뷰 평점, 현지인 리뷰 개수, 현지인 리뷰 평점, 여행객 리뷰 개수, 여행객 리뷰 평점 정보를 조회할 수 있습니다. 
- 목록 조회시에는 페이지네이션을 사용합니다.