### PR TITLE
[#30] 장소 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/example/locavel/converter/PlaceConverter.java
+++ b/src/main/java/com/example/locavel/converter/PlaceConverter.java
@@ -2,6 +2,7 @@ package com.example.locavel.converter;
 
 import com.example.locavel.domain.PlaceImg;
 import com.example.locavel.domain.Places;
+import com.example.locavel.domain.Reviews;
 import com.example.locavel.domain.enums.Category;
 import com.example.locavel.domain.enums.Region;
 import com.example.locavel.web.dto.PlaceDTO.PlaceRequestDTO;
@@ -12,15 +13,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class PlaceConverter {
-
-//    public static PlaceResponseDTO.PlacePreViewDTO toPlacePreViewDTO(Places places) {
-//        return PlaceResponseDTO.PlacePreViewDTO.builder()
-//                .name(places.getName())
-//                .build();
-//    }
-//    public static PlaceResponseDTO.PlacePreViewListDTO toPlacePreViewListDTO(List<Places> placesList){
-//        return null;
-//    }
 
     public static PlaceResponseDTO.PlaceDetailDTO toPlaceDetailDTO(Places places) {
         return PlaceResponseDTO.PlaceDetailDTO.builder()
@@ -101,11 +93,36 @@ public class PlaceConverter {
                 .map(PlaceConverter::toFilterMarkerDTO)
                 .collect(Collectors.toList());
 
-
         return PlaceResponseDTO.FilterMarkerListDTO.builder()
                 .filterMarkerDTOList(filterMarkerDTOList)
                 .category(places.get(0).getCategory().toString())
                 .categoryImgUrl(places.get(0).getCategory().getIconUrl())
+                .build();
+    }
+
+    public static PlaceResponseDTO.FilterPlaceDTO toFilterPlaceDTO(Places place, List<Reviews> reviewsList, List<String> reviewImgList) {
+        return PlaceResponseDTO.FilterPlaceDTO.builder()
+                .placeId(place.getId())
+                .name(place.getName())
+                .address(place.getAddress())
+                .rating(place.getRating())
+                .reviewCount(reviewsList.size())
+                .reviewImgList(reviewImgList)
+                .build();
+    }
+
+    public static PlaceResponseDTO.FilterPlaceListDTO toFilterPlaceListDTO(List<Places> places, List<List<Reviews>> reviewsLists, List<List<String>> reviewImgLists) {
+        List<PlaceResponseDTO.FilterPlaceDTO> filterPlaceDTOList = places.stream()
+                .map(place -> toFilterPlaceDTO(
+                        place,
+                        reviewsLists.get(places.indexOf(place)),
+                        reviewImgLists.get(places.indexOf(place))
+                ))
+                .collect(Collectors.toList());
+
+        return PlaceResponseDTO.FilterPlaceListDTO.builder()
+                .filterPlaceDTOList(filterPlaceDTOList)
+                .category(places.get(0).getCategory().toString())
                 .build();
     }
 }

--- a/src/main/java/com/example/locavel/converter/PlaceConverter.java
+++ b/src/main/java/com/example/locavel/converter/PlaceConverter.java
@@ -9,17 +9,18 @@ import com.example.locavel.web.dto.PlaceDTO.PlaceResponseDTO;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class PlaceConverter {
 
-    public static PlaceResponseDTO.PlacePreViewDTO toPlacePreViewDTO(Places places) {
-        return PlaceResponseDTO.PlacePreViewDTO.builder()
-                .name(places.getName())
-                .build();
-    }
-    public static PlaceResponseDTO.PlacePreViewListDTO toPlacePreViewListDTO(List<Places> placesList){
-        return null;
-    }
+//    public static PlaceResponseDTO.PlacePreViewDTO toPlacePreViewDTO(Places places) {
+//        return PlaceResponseDTO.PlacePreViewDTO.builder()
+//                .name(places.getName())
+//                .build();
+//    }
+//    public static PlaceResponseDTO.PlacePreViewListDTO toPlacePreViewListDTO(List<Places> placesList){
+//        return null;
+//    }
 
     public static PlaceResponseDTO.PlaceDetailDTO toPlaceDetailDTO(Places places) {
         return PlaceResponseDTO.PlaceDetailDTO.builder()
@@ -40,10 +41,10 @@ public class PlaceConverter {
                 .build();
     }
 
-    public static Places toPlace(PlaceRequestDTO.PlaceDTO request, Double latitude, Double longitude, String roadAddress, Region region){
-
+    public static Places toPlace(PlaceRequestDTO.PlaceDTO request,
+                                 Double latitude, Double longitude,
+                                 String roadAddress, Region region){
         Category category = null;
-
         switch (request.getCategory()){
             case "spot":
                 category = Category.spot;
@@ -63,8 +64,8 @@ public class PlaceConverter {
                 .telephoneNumber(request.getTelephoneNumber())
                 .address(roadAddress)
                 .region(region)
-                .latitude(String.valueOf(latitude))
-                .longitude(String.valueOf(longitude))
+                .latitude(latitude)
+                .longitude(longitude)
                 .build();
     }
 
@@ -74,4 +75,17 @@ public class PlaceConverter {
                 .imgUrl(url)
                 .build();
     }
+
+    public static List<PlaceResponseDTO.NearbyMarkerDTO> toNearbyMarkerDTO(List<Places> places) {
+        return places.stream()
+                .map(place -> PlaceResponseDTO.NearbyMarkerDTO.builder()
+                        .placeId(place.getId())
+                        .latitude(place.getLatitude())
+                        .longitude(place.getLongitude())
+                        .category(place.getCategory().toString())
+                        .categoryImgUrl(place.getCategory().getIconUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
+//    public static PlaceResponseDTO.NearbyMarkerDTO toNearbyMarkerDTO(Places places) {}
 }

--- a/src/main/java/com/example/locavel/converter/PlaceConverter.java
+++ b/src/main/java/com/example/locavel/converter/PlaceConverter.java
@@ -87,5 +87,25 @@ public class PlaceConverter {
                         .build())
                 .collect(Collectors.toList());
     }
-//    public static PlaceResponseDTO.NearbyMarkerDTO toNearbyMarkerDTO(Places places) {}
+
+    public static PlaceResponseDTO.FilterMarkerDTO toFilterMarkerDTO(Places places) {
+        return PlaceResponseDTO.FilterMarkerDTO.builder()
+                .placeId(places.getId())
+                .latitude(places.getLatitude())
+                .longitude(places.getLongitude())
+                .build();
+    }
+
+    public static PlaceResponseDTO.FilterMarkerListDTO toFilterMarkerListDTO(List<Places> places) {
+        List<PlaceResponseDTO.FilterMarkerDTO> filterMarkerDTOList = places.stream()
+                .map(PlaceConverter::toFilterMarkerDTO)
+                .collect(Collectors.toList());
+
+
+        return PlaceResponseDTO.FilterMarkerListDTO.builder()
+                .filterMarkerDTOList(filterMarkerDTOList)
+                .category(places.get(0).getCategory().toString())
+                .categoryImgUrl(places.get(0).getCategory().getIconUrl())
+                .build();
+    }
 }

--- a/src/main/java/com/example/locavel/domain/Places.java
+++ b/src/main/java/com/example/locavel/domain/Places.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/com/example/locavel/domain/Places.java
+++ b/src/main/java/com/example/locavel/domain/Places.java
@@ -27,9 +27,9 @@ public class Places extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Region region;
 
-    private String longitude; //경도
+    private double longitude; //경도
 
-    private String latitude; //위도
+    private double latitude; //위도
 
     private String address;
 

--- a/src/main/java/com/example/locavel/domain/enums/Category.java
+++ b/src/main/java/com/example/locavel/domain/enums/Category.java
@@ -1,7 +1,16 @@
 package com.example.locavel.domain.enums;
 
+import lombok.Getter;
+
 public enum Category {
-    spot,
-    food,
-    activity
+    spot("https://d2e0trgpaip524.cloudfront.net/spot.png"),
+    food("https://d2e0trgpaip524.cloudfront.net/food.png"),
+    activity("https://d2e0trgpaip524.cloudfront.net/activity.png");
+
+    @Getter
+    private final String iconUrl;
+
+    Category(String iconUrl) {
+        this.iconUrl = iconUrl;
+    }
 }

--- a/src/main/java/com/example/locavel/repository/PlaceRepository.java
+++ b/src/main/java/com/example/locavel/repository/PlaceRepository.java
@@ -2,6 +2,7 @@ package com.example.locavel.repository;
 
 import com.example.locavel.domain.Places;
 import com.example.locavel.domain.User;
+import com.example.locavel.domain.enums.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,6 @@ public interface PlaceRepository extends JpaRepository<Places, Long> {
             @Param("swLng") double swLng,
             @Param("neLat") double neLat,
             @Param("neLng") double neLng);
+
+    List<Places> findByCategory(Category category);
 }

--- a/src/main/java/com/example/locavel/repository/PlaceRepository.java
+++ b/src/main/java/com/example/locavel/repository/PlaceRepository.java
@@ -5,9 +5,20 @@ import com.example.locavel.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PlaceRepository extends JpaRepository<Places, Long> {
     Places findByAddress(String address);
+
+    @Query("SELECT p FROM Places p WHERE p.latitude BETWEEN :swLat AND :neLat AND p.longitude BETWEEN :swLng AND :neLng")
+    List<Places> findPlacesInRange(
+            @Param("swLat") double swLat,
+            @Param("swLng") double swLng,
+            @Param("neLat") double neLat,
+            @Param("neLng") double neLng);
 }

--- a/src/main/java/com/example/locavel/repository/ReviewRepository.java
+++ b/src/main/java/com/example/locavel/repository/ReviewRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Reviews, Long>, JpaSpecificationExecutor<Reviews> {
     Page<Reviews> findAllByUser(User user, PageRequest pageRequest);
     Long countAllByPlaceAndTraveler(Places place, Traveler traveler);
@@ -21,4 +23,6 @@ public interface ReviewRepository extends JpaRepository<Reviews, Long>, JpaSpeci
 
     @Query("select avg(r.rating) from Reviews r where r.place.id = :placeId and r.traveler = :traveler")
     Float getAvgRatingByPlaceAndTraveler(@Param("placeId")Long placeId, @Param("traveler")Traveler traveler);
+
+    List<Reviews> findAllByPlace(Places places);
 }

--- a/src/main/java/com/example/locavel/service/PlaceService.java
+++ b/src/main/java/com/example/locavel/service/PlaceService.java
@@ -3,18 +3,15 @@ package com.example.locavel.service;
 import com.example.locavel.apiPayload.code.status.ErrorStatus;
 import com.example.locavel.apiPayload.exception.handler.PlacesHandler;
 import com.example.locavel.converter.PlaceConverter;
-import com.example.locavel.converter.ReviewConverter;
 import com.example.locavel.domain.PlaceImg;
 import com.example.locavel.domain.Places;
-import com.example.locavel.domain.ReviewImg;
-import com.example.locavel.domain.Reviews;
 import com.example.locavel.domain.enums.Category;
 import com.example.locavel.domain.enums.Region;
 import com.example.locavel.repository.PlaceImgRepository;
 import com.example.locavel.repository.PlaceRepository;
+import com.example.locavel.repository.ReviewRepository;
 import com.example.locavel.web.dto.MapDTO.MapResponseDTO;
 import com.example.locavel.web.dto.PlaceDTO.PlaceRequestDTO;
-import com.example.locavel.web.dto.PlaceDTO.PlaceResponseDTO;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,14 +19,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -119,11 +111,15 @@ public class PlaceService {
         return places;
     }
 
-    public List<Places> getFilterMarkers(String category){
-        // Enum에서 카테고리 변환
+    public List<Places> getFilterPlaces(String category) {
         Category cat = Category.valueOf(category.toLowerCase());
         return placeRepository.findByCategory(cat);
     }
+
+//    public PlaceResponseDTO.FilterPlaceListDTO getFilterPlaceListDTO(String category) {
+//        List<Places> places = getFilterPlaces(category);
+//        return placeConverter.toFilterPlaceListDTO(places, reviewService);
+//    }
 
 //    public Page<Places> getPlaceList(Region region, Integer page) {
 //

--- a/src/main/java/com/example/locavel/service/PlaceService.java
+++ b/src/main/java/com/example/locavel/service/PlaceService.java
@@ -8,6 +8,7 @@ import com.example.locavel.domain.PlaceImg;
 import com.example.locavel.domain.Places;
 import com.example.locavel.domain.ReviewImg;
 import com.example.locavel.domain.Reviews;
+import com.example.locavel.domain.enums.Category;
 import com.example.locavel.domain.enums.Region;
 import com.example.locavel.repository.PlaceImgRepository;
 import com.example.locavel.repository.PlaceRepository;
@@ -116,6 +117,12 @@ public class PlaceService {
     public List<Places> getNearbyMarkers(float swLat, float swLng, float neLat, float neLng) {
         List<Places> places = placeRepository.findPlacesInRange(swLat, swLng, neLat, neLng);
         return places;
+    }
+
+    public List<Places> getFilterMarkers(String category){
+        // Enum에서 카테고리 변환
+        Category cat = Category.valueOf(category.toLowerCase());
+        return placeRepository.findByCategory(cat);
     }
 
 //    public Page<Places> getPlaceList(Region region, Integer page) {

--- a/src/main/java/com/example/locavel/service/ReviewService.java
+++ b/src/main/java/com/example/locavel/service/ReviewService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -121,5 +122,16 @@ public class ReviewService {
         Long generalCount = reviewRepository.countAllByPlaceAndTraveler(place, Traveler.NO);
 
         return ReviewConverter.toPlaceReviewSummaryDTO(totalRating, totalCount, generalRating, generalCount, travelerRating, travelerCount);
+    }
+
+    public List<Reviews> getReviewsByPlace(Places place) {
+        return reviewRepository.findAllByPlace(place);
+    }
+
+    public List<String> getReviewImagesByPlace(Places place) {
+        return reviewRepository.findAllByPlace(place).stream()
+                .flatMap(review -> review.getReviewImgList().stream())
+                .map(ReviewImg::getImgUrl)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
@@ -40,6 +40,19 @@ public class PlaceRestController {
         return ApiResponse.onSuccess(PlaceConverter.toPlaceResultDTO(place));
     }
 
+    @GetMapping("/api/places/map")
+    @Operation(summary = "내 주변 장소 조회(마커) API", description = "지도뷰에서 내 주변 장소를 조회하는 API입니다.")
+    public ApiResponse<List<PlaceResponseDTO.NearbyMarkerDTO>> getNearbyMarker(@RequestParam float swLat,    // 남서쪽 구석 위도
+                                                                         @RequestParam float swLng,    // 납서쪽 구석 경도
+                                                                         @RequestParam float neLat,    // 북동쪽 구석 위도
+                                                                         @RequestParam float neLng){   // 북동쪽 구석 경도
+
+        List<Places> places = placeService.getNearbyMarkers(swLat, swLng, neLat, neLng);
+        return ApiResponse.onSuccess(PlaceConverter.toNearbyMarkerDTO(places));
+//        placeService.getPlacesInBounds(swLat, swLng, neLat, neLng);
+//        return ApiResponse.onSuccess(PlaceConverter.toNearbyMarkerDTO());
+    }
+
 
 //    @GetMapping("/api/places/list")
 //    @Operation(summary = "지도에서 목록 버튼으로 가게 목록 조회 API", description = "현재 지도 화면의 가게 목록을 조회하는 API이며, 페이징을 포함합니다. query String 으로 page 번호를 주세요")

--- a/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
@@ -31,6 +31,7 @@ public class PlaceRestController {
     }
 
     @PostMapping(value = "/api/places", consumes = "multipart/form-data")
+    @Operation(summary = "장소 등록 API", description = "새로운 장소를 등록하는 API입니다. 장소명, 별점은 필수로 입력해야 합니다.")
     public ApiResponse<PlaceResponseDTO.PlaceResultDTO> createPlace(@Valid @RequestPart PlaceRequestDTO.PlaceDTO placeDTO,
                                                                     @RequestPart(required = false) List<MultipartFile> placeImgUrls) {
         if(placeDTO.getRating() > 5 || placeDTO.getRating() <0) {
@@ -49,8 +50,14 @@ public class PlaceRestController {
 
         List<Places> places = placeService.getNearbyMarkers(swLat, swLng, neLat, neLng);
         return ApiResponse.onSuccess(PlaceConverter.toNearbyMarkerDTO(places));
-//        placeService.getPlacesInBounds(swLat, swLng, neLat, neLng);
-//        return ApiResponse.onSuccess(PlaceConverter.toNearbyMarkerDTO());
+    }
+
+    @GetMapping("/api/places/filters")
+    @Operation(summary = "스팟, 푸드, 액티비티 필터 조회(마커) API", description = "지도뷰에서 스팟, 푸드, 액티비티 필터로 장소 위치를 조회하는 API입니다.")
+    public ApiResponse<PlaceResponseDTO.FilterMarkerListDTO> getFilterMarker(@RequestParam String category){
+        List<Places> places = placeService.getFilterMarkers(category);
+        return ApiResponse.onSuccess(PlaceConverter.toFilterMarkerListDTO(places));
+
     }
 
 

--- a/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
@@ -5,7 +5,9 @@ import com.example.locavel.apiPayload.code.status.ErrorStatus;
 import com.example.locavel.apiPayload.exception.handler.ReviewsHandler;
 import com.example.locavel.converter.PlaceConverter;
 import com.example.locavel.domain.Places;
+import com.example.locavel.domain.Reviews;
 import com.example.locavel.service.PlaceService;
+import com.example.locavel.service.ReviewService;
 import com.example.locavel.web.dto.PlaceDTO.PlaceRequestDTO;
 import com.example.locavel.web.dto.PlaceDTO.PlaceResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,12 +18,14 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
 public class PlaceRestController {
 
     private final PlaceService placeService;
+    private final ReviewService reviewService;
 
     @GetMapping("/api/places/{placeId}")
     @Operation(summary = "특정 장소 상세 조회 API", description = "특정 장소를 상세 조회하는 API입니다. query String으로 place 번호를 주세요")
@@ -55,9 +59,23 @@ public class PlaceRestController {
     @GetMapping("/api/places/filters")
     @Operation(summary = "스팟, 푸드, 액티비티 필터 조회(마커) API", description = "지도뷰에서 스팟, 푸드, 액티비티 필터로 장소 위치를 조회하는 API입니다.")
     public ApiResponse<PlaceResponseDTO.FilterMarkerListDTO> getFilterMarker(@RequestParam String category){
-        List<Places> places = placeService.getFilterMarkers(category);
+        List<Places> places = placeService.getFilterPlaces(category);
         return ApiResponse.onSuccess(PlaceConverter.toFilterMarkerListDTO(places));
+    }
 
+    @GetMapping("/api/places/list")
+    public ApiResponse<PlaceResponseDTO.FilterPlaceListDTO> getFilterPlaceList(@RequestParam String category) {
+        List<Places> places = placeService.getFilterPlaces(category);
+
+        List<List<Reviews>> reviewsLists = places.stream()
+                .map(reviewService::getReviewsByPlace)
+                .collect(Collectors.toList());
+
+        List<List<String>> reviewImgLists = places.stream()
+                .map(reviewService::getReviewImagesByPlace)
+                .collect(Collectors.toList());
+
+        return ApiResponse.onSuccess(PlaceConverter.toFilterPlaceListDTO(places, reviewsLists, reviewImgLists));
     }
 
 

--- a/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceResponseDTO.java
@@ -8,34 +8,34 @@ import java.util.List;
 
 public class PlaceResponseDTO {
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class PlacePreViewListDTO{
-        List<PlacePreViewDTO> placeList;
-        Integer listSize;
-        Integer totalPage;
-        Long totalElements;
-        Boolean isFirst;
-        Boolean isLast;
-    }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class PlacePreViewDTO{
-        String name;
-        String address;
-        Float rating;
-        Integer reviewCount;
-        String category;
-        // img 사진
-//        String longitude; //경도
-//        String latitude; //위도
-        LocalDate createdAt;
-    }
+//    @Getter
+//    @Builder
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class PlacePreViewListDTO{
+//        List<PlacePreViewDTO> placeList;
+//        Integer listSize;
+//        Integer totalPage;
+//        Long totalElements;
+//        Boolean isFirst;
+//        Boolean isLast;
+//    }
+//
+//    @Getter
+//    @Builder
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class PlacePreViewDTO{
+//        String name;
+//        String address;
+//        Float rating;
+//        Integer reviewCount;
+//        String category;
+//        // img 사진
+////        String longitude; //경도
+////        String latitude; //위도
+//        LocalDate createdAt;
+//    }
 
     @Getter
     @Builder
@@ -45,8 +45,8 @@ public class PlaceResponseDTO {
         Long placeId;
         String name;
         String address;
-        String longitude; //경도
-        String latitude; //위도
+        double longitude; //경도
+        double latitude; //위도
         Float generalRating;
         Float travelerRating;
         // img reviewImage
@@ -61,4 +61,15 @@ public class PlaceResponseDTO {
         LocalDateTime createdAt;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NearbyMarkerDTO{
+        Long placeId;
+        Double latitude;    // 위도
+        Double longitude;  // 경도
+        String category;
+        String categoryImgUrl;  // 카테고리 아이콘 이미지 url
+    }
 }

--- a/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceResponseDTO.java
@@ -72,4 +72,24 @@ public class PlaceResponseDTO {
         String category;
         String categoryImgUrl;  // 카테고리 아이콘 이미지 url
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FilterMarkerDTO{
+        Long placeId;
+        Double latitude;    // 위도
+        Double longitude;  // 경도
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FilterMarkerListDTO{
+        List<FilterMarkerDTO> filterMarkerDTOList;
+        String category;
+        String categoryImgUrl;
+    }
 }

--- a/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceResponseDTO.java
@@ -92,4 +92,28 @@ public class PlaceResponseDTO {
         String category;
         String categoryImgUrl;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FilterPlaceDTO{
+        Long placeId;
+        String name;
+        String address;
+        Float rating;
+        int reviewCount;
+        List<String> reviewImgList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FilterPlaceListDTO{
+        List<FilterPlaceDTO> filterPlaceDTOList;
+        String category;
+    }
+
+
 }


### PR DESCRIPTION
### 📌 관련 이슈
- #30 

### 💻 작업 내용
- Category enum에 카테고리 icon 이미지 url을 추가했습니다.
- **내 주변 장소 조회 API**를 구현했습니다. 보여지는 지도의 남서쪽 위도, 경도와 북동쪽 위도, 경도 값을 쿼리스트링으로 받습니다.
- 스팟, 푸드, 액티비티 **필터 조회 API(마커)** 를 구현했습니다. 필터를 통해 각 장소를 마커로 표시할 수 있습니다.
- 스팟, 푸드, 액티비티 **필터 조회 API(목록버튼)** 를 구현했습니다. 