### PR TITLE
[#42] 팔로우 관련 기능 구현

### DIFF
--- a/src/main/java/com/example/locavel/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/locavel/apiPayload/code/status/ErrorStatus.java
@@ -40,6 +40,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //유저
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001","해당 유저가 존재하지 않습니다."),
+    USER_SAME(HttpStatus.BAD_REQUEST,"USER4002","본인입니다."),
+
+    //팔로우
+    FOLLOWING_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW4001","팔로우 중이 아닙니다."),
+    ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST,"FOLLOW4002","이미 팔로잉 중입니다."),
 
 
     //약관 동의

--- a/src/main/java/com/example/locavel/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/locavel/apiPayload/code/status/SuccessStatus.java
@@ -33,6 +33,11 @@ public enum SuccessStatus implements BaseCode {
     PLACE_GET_OK(HttpStatus.OK, "PLACE2004", "장소를 조회했습니다."),
     PLACE_LIST_GET_OK(HttpStatus.OK, "PLACE2004", "장소 목록을 조회했습니다."),
     PLACE_MARKER_GET_OK(HttpStatus.OK, "PLACE2004", "장소 마커 정보를 조회했습니다."),
+
+    //팔로우
+    FOLLOW_OK(HttpStatus.OK, "FOLLOW2001", "팔로우가 완료되었습니다."),
+    FOLLOW_DELETE_OK(HttpStatus.OK,"FOLLOW2002","팔로우 취소가 완료되었습니다."),
+    FOLLOW_GET_OK(HttpStatus.OK,"FOLLOW2003","팔로우 목록을 조회했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/locavel/apiPayload/exception/handler/FollowHandler.java
+++ b/src/main/java/com/example/locavel/apiPayload/exception/handler/FollowHandler.java
@@ -1,0 +1,10 @@
+package com.example.locavel.apiPayload.exception.handler;
+
+import com.example.locavel.apiPayload.code.BaseErrorCode;
+import com.example.locavel.apiPayload.exception.GeneralException;
+
+public class FollowHandler extends GeneralException {
+    public FollowHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/locavel/converter/FollowConverter.java
+++ b/src/main/java/com/example/locavel/converter/FollowConverter.java
@@ -1,0 +1,39 @@
+package com.example.locavel.converter;
+
+import com.example.locavel.domain.Follow;
+import com.example.locavel.domain.User;
+import com.example.locavel.web.dto.FollowDTO.FollowResponseDTO;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FollowConverter {
+    public static Follow toFollow(User user, Long followUserId) {
+        return Follow.builder()
+                .user(user)
+                .followUserId(followUserId)
+                .build();
+    }
+    public static FollowResponseDTO.FollowPreviewDTO toFollowPreviewDTO(User user) {
+        return FollowResponseDTO.FollowPreviewDTO.builder()
+                .nickname(user.getNickname())
+                .profile(user.getProfileImage())
+                .userId(user.getId())
+                //TODO:등급추가
+                .build();
+    }
+
+    public static FollowResponseDTO.FollowPreviewListDTO toFollowPreviewListDTO(Page<User> followList) {
+        List<FollowResponseDTO.FollowPreviewDTO> followPreviewListDTOList = followList.stream()
+                .map(FollowConverter::toFollowPreviewDTO).collect(Collectors.toList());
+        return FollowResponseDTO.FollowPreviewListDTO.builder()
+                .followList(followPreviewListDTOList)
+                .listSize(followList.getSize())
+                .isFirst(followList.isFirst())
+                .isLast(followList.isLast())
+                .totalElements(followList.getTotalElements())
+                .totalPage(followList.getTotalPages())
+                .build();
+    }
+}

--- a/src/main/java/com/example/locavel/converter/ReviewConverter.java
+++ b/src/main/java/com/example/locavel/converter/ReviewConverter.java
@@ -60,6 +60,7 @@ public class ReviewConverter {
                 .comment(review.getComment())
                 .createdAt(review.getCreated_at())
                 .updatedAt(review.getUpdated_at())
+                .reviewerFollowerCount(user.getFollowerCount())
                 .build();
     }
     public ReviewResponseDTO.ReviewPreviewListDTO toReviewPreviewListDTO(Page<Reviews> reviewList) {
@@ -143,6 +144,7 @@ public class ReviewConverter {
                 .createdAt(review.getCreated_at())
                 .placeName(place.getName())
                 .comment(review.getComment())
+                .reviewerFollowerCount(user.getFollowerCount())
                 .build();
     }
 

--- a/src/main/java/com/example/locavel/converter/ReviewConverter.java
+++ b/src/main/java/com/example/locavel/converter/ReviewConverter.java
@@ -26,7 +26,7 @@ public class ReviewConverter {
                 .createdAt(LocalDateTime.now())
                 .build();
     }
-    public static Reviews toReviews(User user, Traveler traveler, Places place, ReviewRequestDTO.RevieweDTO request) {
+    public static Reviews toReviews(User user, Traveler traveler, Places place, ReviewRequestDTO.ReviewDTO request) {
         return Reviews.builder()
                 .comment(request.getComment())
                 .user(user)

--- a/src/main/java/com/example/locavel/domain/Follow.java
+++ b/src/main/java/com/example/locavel/domain/Follow.java
@@ -1,0 +1,20 @@
+package com.example.locavel.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+public class Follow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long followUserId; //팔로우 대상 유저 id(유저 입장에서 팔로잉중인 유저 id)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user; //유저
+}

--- a/src/main/java/com/example/locavel/domain/User.java
+++ b/src/main/java/com/example/locavel/domain/User.java
@@ -71,10 +71,16 @@ public class User extends BaseEntity {
     private LocalDateTime deleted_at;
 
     private LocalDateTime updated_at;
+    @Builder.Default
+    private Integer followingCount = 0;
+    @Builder.Default
+    private Integer followerCount = 0;
 
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<TermAgreement> termAgreementList = new ArrayList<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Follow> followList = new ArrayList<>();
 
     //유저 권한 GUEST -> USER 로
     public void authorizeUser(){
@@ -102,4 +108,8 @@ public class User extends BaseEntity {
     public void setIntroduce(String introduce){this.introduce = introduce;}
 
     public void setPhone_num(String phone_num){this.phone_num = phone_num;}
+    public void setFollowingCountPlus(){this.followingCount++;}
+    public void setFollowerCountPlus(){this.followerCount++;}
+    public void setFollowingCountMinus(){this.followingCount--;}
+    public void setFollowerCountMinus(){this.followerCount--;}
 }

--- a/src/main/java/com/example/locavel/repository/FollowRepository.java
+++ b/src/main/java/com/example/locavel/repository/FollowRepository.java
@@ -1,0 +1,17 @@
+package com.example.locavel.repository;
+
+import com.example.locavel.domain.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    Follow findByUserIdAndFollowUserId(Long userId, Long followUserId);
+
+    @Query("select f.followUserId from Follow f where f.user.id = :userId")
+    List<Long> findAllFollowUserIdByUserId(@Param("userId") Long userId);
+    @Query("select f.user.id from Follow f where f.followUserId = :followUserId")
+    List<Long> findAllUserIdByFollowUserId(@Param("followUserId")Long followUserId);
+}

--- a/src/main/java/com/example/locavel/repository/UserRepository.java
+++ b/src/main/java/com/example/locavel/repository/UserRepository.java
@@ -2,8 +2,11 @@ package com.example.locavel.repository;
 
 import com.example.locavel.domain.User;
 import com.example.locavel.domain.enums.SocialType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -16,4 +19,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 
     Optional<User> findByRefreshToken(String refreshToken);
+    Page<User> findAllByIdIn(List<Long> userId, PageRequest pageRequest);
 }

--- a/src/main/java/com/example/locavel/service/FollowService.java
+++ b/src/main/java/com/example/locavel/service/FollowService.java
@@ -1,0 +1,61 @@
+package com.example.locavel.service;
+
+import com.example.locavel.apiPayload.code.status.ErrorStatus;
+import com.example.locavel.apiPayload.exception.handler.FollowHandler;
+import com.example.locavel.apiPayload.exception.handler.UserHandler;
+import com.example.locavel.converter.FollowConverter;
+import com.example.locavel.domain.Follow;
+import com.example.locavel.domain.User;
+import com.example.locavel.repository.FollowRepository;
+import com.example.locavel.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+    public void createFollow(User user, User followUser) {
+        if(user.getId().equals(followUser.getId())) {throw new UserHandler(ErrorStatus.USER_SAME);}
+        if(isFollowing(user, followUser.getId())) {throw new FollowHandler(ErrorStatus.ALREADY_FOLLOWING);}
+
+        Follow follow = FollowConverter.toFollow(user, followUser.getId());
+        followRepository.save(follow);
+        user.setFollowingCountPlus();
+        followUser.setFollowerCountPlus();
+        userRepository.save(user);
+        userRepository.save(followUser);
+    }
+    public void deleteFollow(User user, User followUser) { // user : 팔로우하는 사람, followUser : 팔로우 당하는 유저
+        if(user.getId().equals(followUser.getId())) {throw new UserHandler(ErrorStatus.USER_SAME);}
+        if(!isFollowing(user, followUser.getId())) {throw new FollowHandler(ErrorStatus.FOLLOWING_NOT_FOUND);}
+        else{
+            Follow follow = followRepository.findByUserIdAndFollowUserId(user.getId(), followUser.getId());
+            user.setFollowingCountMinus();
+            followUser.setFollowerCountMinus();
+            followRepository.delete(follow);
+        }
+    }
+    public Page<User> getFollowingList(User user, Integer page) {
+        List<Long> followingList = followRepository.findAllFollowUserIdByUserId(user.getId());
+        Page<User> followingUserList = userRepository.findAllByIdIn(followingList, PageRequest.of(page,10));
+        return followingUserList;
+    }
+
+    public Page<User> getFollowerList(User user, Integer page) {
+        List<Long> followerList = followRepository.findAllUserIdByFollowUserId(user.getId());
+        Page<User> followerUserList = userRepository.findAllByIdIn(followerList, PageRequest.of(page,10));
+        return followerUserList;
+    }
+
+    public boolean isFollowing(User user, Long followUserId) {
+        Follow follow = followRepository.findByUserIdAndFollowUserId(user.getId(), followUserId);
+        if(follow == null) {return false;}
+        else {return true;}
+    }
+}

--- a/src/main/java/com/example/locavel/service/ReviewService.java
+++ b/src/main/java/com/example/locavel/service/ReviewService.java
@@ -32,10 +32,7 @@ public class ReviewService {
     private final PlaceRepository placeRepository;
     private final ReviewImgRepository reviewImgRepository;
     private final S3Uploader s3Uploader;
-    public ReviewResponseDTO.ReviewResultDTO createReview(Long placeId, ReviewRequestDTO.RevieweDTO request, List<MultipartFile> reviewImgUrls) {
-        //TODO : JWT 토큰 추가 후 변경
-        User user = userRepository.findById(request.getUserId())
-                .orElseThrow(()->new RuntimeException("해당하는 유저가 없습니다."));
+    public ReviewResponseDTO.ReviewResultDTO createReview(User user, Long placeId, ReviewRequestDTO.ReviewDTO request, List<MultipartFile> reviewImgUrls) {
         Places place = placeRepository.findById(placeId)
                 .orElseThrow(()->new ReviewsHandler(ErrorStatus.PLACE_NOT_FOUND));
         Traveler traveler = Traveler.of(place, user);
@@ -47,7 +44,7 @@ public class ReviewService {
         return ReviewConverter.toReviewResultDTO(savedReview);
     }
 
-    public ReviewResponseDTO.ReviewUpdateResultDTO updateReview(Long reviewId, ReviewRequestDTO.RevieweDTO request, List<MultipartFile> reviewImgUrls) {
+    public ReviewResponseDTO.ReviewUpdateResultDTO updateReview(Long reviewId, ReviewRequestDTO.ReviewDTO request, List<MultipartFile> reviewImgUrls) {
         Reviews review = reviewRepository.findById(reviewId)
                 .orElseThrow(()->new ReviewsHandler(ErrorStatus.REVIEW_NOT_FOUND));
         if(request.getRating() != null) {review.setRating(request.getRating());}

--- a/src/main/java/com/example/locavel/web/controller/FollowRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/FollowRestController.java
@@ -1,0 +1,82 @@
+package com.example.locavel.web.controller;
+
+import com.example.locavel.apiPayload.ApiResponse;
+import com.example.locavel.apiPayload.code.status.ErrorStatus;
+import com.example.locavel.apiPayload.code.status.SuccessStatus;
+import com.example.locavel.apiPayload.exception.handler.UserHandler;
+import com.example.locavel.converter.FollowConverter;
+import com.example.locavel.domain.User;
+import com.example.locavel.repository.UserRepository;
+import com.example.locavel.service.FollowService;
+import com.example.locavel.service.userService.UserCommandService;
+import com.example.locavel.web.dto.FollowDTO.FollowRequestDTO;
+import com.example.locavel.web.dto.FollowDTO.FollowResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/follows")
+public class FollowRestController {
+    private final UserCommandService userCommandService;
+    private final FollowService followService;
+    private final UserRepository userRepository;
+    @Operation(summary = "팔로잉", description = "유저를 팔로우합니다.")
+    @PostMapping
+    public ApiResponse createFollow(
+            HttpServletRequest httpServletRequest,
+            @Valid @RequestBody FollowRequestDTO.FollowDTO request) {
+        User user = userCommandService.getUser(httpServletRequest);
+        User followUser = userRepository.findById(request.getFollowUserId())
+                        .orElseThrow(()->new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        followService.createFollow(user, followUser);
+        return ApiResponse.of(SuccessStatus.FOLLOW_OK,null);
+    }
+    @Operation(summary = "팔로잉 삭제", description = "본인이 팔로우 중인 유저를 삭제합니다.")
+    @DeleteMapping("/followings")
+    public ApiResponse deleteFollowing(
+            HttpServletRequest httpServletRequest,
+            @Valid @RequestBody FollowRequestDTO.FollowDTO request) {
+        User user = userCommandService.getUser(httpServletRequest);
+        User followUser = userRepository.findById(request.getFollowUserId())
+                .orElseThrow(()->new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        followService.deleteFollow(user, followUser);
+        return ApiResponse.of(SuccessStatus.FOLLOW_DELETE_OK,null);
+    }
+    @Operation(summary = "팔로워 삭제", description = "본인을 팔로우하는 유저를 삭제합니다.")
+    @DeleteMapping("/followers")
+    public ApiResponse deleteFollower(
+            HttpServletRequest httpServletRequest,
+            @Valid @RequestBody FollowRequestDTO.FollowDTO request) {
+        User user = userCommandService.getUser(httpServletRequest);
+        User followUser = userRepository.findById(request.getFollowUserId())
+                        .orElseThrow(()->new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        followService.deleteFollow(followUser,user);
+        return ApiResponse.of(SuccessStatus.FOLLOW_DELETE_OK,null);
+    }
+
+    @Operation(summary = "팔로잉 목록 조회", description = "유저가 팔로우 중인 유저 목록을 조회합니다.")
+    @GetMapping("/followings")
+    public ApiResponse<FollowResponseDTO.FollowPreviewListDTO> getFollowings(
+            HttpServletRequest httpServletRequest,
+            @RequestParam(name = "page") Integer page) {
+        User user = userCommandService.getUser(httpServletRequest);
+        Page<User> followingList = followService.getFollowingList(user, page-1);
+        FollowResponseDTO.FollowPreviewListDTO response = FollowConverter.toFollowPreviewListDTO(followingList);
+        return ApiResponse.of(SuccessStatus.FOLLOW_GET_OK,response);
+    }
+    @Operation(summary = "팔로워 목록 조회", description = "유저를 팔로우 중인 유저 목록을 조회합니다.")
+    @GetMapping("/followers")
+    public ApiResponse<FollowResponseDTO.FollowPreviewListDTO> getFollowers(
+            HttpServletRequest httpServletRequest,
+            @RequestParam(name = "page") Integer page) {
+        User user = userCommandService.getUser(httpServletRequest);
+        Page<User> followerList = followService.getFollowerList(user, page-1);
+        FollowResponseDTO.FollowPreviewListDTO response = FollowConverter.toFollowPreviewListDTO(followerList);
+        return ApiResponse.of(SuccessStatus.FOLLOW_GET_OK,response);
+    }
+}

--- a/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
@@ -6,13 +6,16 @@ import com.example.locavel.apiPayload.code.status.SuccessStatus;
 import com.example.locavel.apiPayload.exception.handler.ReviewsHandler;
 import com.example.locavel.converter.ReviewConverter;
 import com.example.locavel.domain.Reviews;
+import com.example.locavel.domain.User;
 import com.example.locavel.domain.enums.Traveler;
 import com.example.locavel.service.ReviewService;
+import com.example.locavel.service.userService.UserCommandService;
 import com.example.locavel.web.dto.ReviewDTO.ReviewRequestDTO;
 import com.example.locavel.web.dto.ReviewDTO.ReviewResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,11 +30,13 @@ import java.util.List;
 public class ReviewRestController {
     private final ReviewService reviewService;
     private final ReviewConverter reviewConverter;
+    private final UserCommandService userCommandService;
 
     @Operation(summary = "리뷰 등록", description = "리뷰를 등록합니다.")
     @PostMapping(value = "/{placeId}", consumes = "multipart/form-data")
     public ApiResponse<ReviewResponseDTO.ReviewResultDTO> createReview(
-            @Valid @RequestPart ReviewRequestDTO.RevieweDTO request,
+            HttpServletRequest httpServletRequest,
+            @Valid @RequestPart ReviewRequestDTO.ReviewDTO request,
             @PathVariable(name="placeId") Long placeId,
             @RequestPart(required = false) List<MultipartFile> reviewImgUrls) {
         if(request.getRating() == null) {
@@ -40,14 +45,15 @@ public class ReviewRestController {
         if(request.getRating() > 5 || request.getRating() <0) {
             throw new ReviewsHandler(ErrorStatus.RATING_NOT_VALID);
         }
-        ReviewResponseDTO.ReviewResultDTO response = reviewService.createReview(placeId, request, reviewImgUrls);
+        User user = userCommandService.getUser(httpServletRequest);
+        ReviewResponseDTO.ReviewResultDTO response = reviewService.createReview(user, placeId, request, reviewImgUrls);
         return ApiResponse.of(SuccessStatus.REVIEW_CREATE_OK,response);
     }
 
     @Operation(summary = "리뷰 수정", description = "리뷰를 수정합니다.")
     @PatchMapping(value = "/{reviewId}", consumes = "multipart/form-data")
     public ApiResponse<ReviewResponseDTO.ReviewUpdateResultDTO> updateReview(
-            @Valid @RequestPart ReviewRequestDTO.RevieweDTO request,
+            @Valid @RequestPart ReviewRequestDTO.ReviewDTO request,
             @PathVariable(name="reviewId") Long reviewId,
             @RequestPart(required = false) List<MultipartFile> reviewImgUrls) {
         if(request.getRating() > 5 || request.getRating() <0) {
@@ -86,13 +92,15 @@ public class ReviewRestController {
     }
 
     @Operation(summary = "유저 리뷰 목록 조회", description = "특정 유저가 작성한 리뷰 목록을 조회합니다.")
-    @GetMapping(value = "/users/{userId}")
+    @GetMapping(value = "/users")
     public ApiResponse<ReviewResponseDTO.MyReviewListDTO> getMyReviews(
-            @PathVariable(name="userId")Long userId,
+            HttpServletRequest httpServletRequest,
             @RequestParam(name = "page") Integer page) {
         if(page<=0){
             throw new ReviewsHandler(ErrorStatus.PAGE_NOT_VALID);
         }
+        User user = userCommandService.getUser(httpServletRequest);
+        Long userId = user.getId();
         Page<Reviews> myReviewList = reviewService.getMyReviewList(userId,page-1);
         ReviewResponseDTO.MyReviewListDTO response = reviewConverter.toMyReviewListDTO(myReviewList);
         return ApiResponse.of(SuccessStatus.REVIEW_GET_OK,response);

--- a/src/main/java/com/example/locavel/web/dto/FollowDTO/FollowRequestDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/FollowDTO/FollowRequestDTO.java
@@ -1,0 +1,10 @@
+package com.example.locavel.web.dto.FollowDTO;
+
+import lombok.Getter;
+
+public class FollowRequestDTO {
+    @Getter
+    public static class FollowDTO {
+        Long followUserId;
+    }
+}

--- a/src/main/java/com/example/locavel/web/dto/FollowDTO/FollowResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/FollowDTO/FollowResponseDTO.java
@@ -1,0 +1,36 @@
+package com.example.locavel.web.dto.FollowDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class FollowResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FollowPreviewListDTO {
+        List<FollowResponseDTO.FollowPreviewDTO> followList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FollowPreviewDTO {
+        Long userId;
+        String profile;
+        String nickname;
+        //TODO : 등급 기능 추가 후 등급 추가
+//        Grade generalGrade;
+//        Grade travelerGrade;
+
+    }
+}

--- a/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewRequestDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewRequestDTO.java
@@ -7,9 +7,7 @@ import lombok.Setter;
 public class ReviewRequestDTO {
     @Getter
     @Setter
-    public static class RevieweDTO {
-        //TODO :  JWT 토큰 추가 후 userId 삭제
-        Long userId;
+    public static class ReviewDTO {
         String comment;
         @NotNull
         Float rating;

--- a/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/ReviewDTO/ReviewResponseDTO.java
@@ -48,6 +48,7 @@ public class ReviewResponseDTO {
         String traveler;
         String reviewerName;
         String reviewerImg;
+        Integer reviewerFollowerCount;
         List<String> reviewImgList;
         String comment;
         Float Rating;
@@ -109,6 +110,7 @@ public class ReviewResponseDTO {
         String traveler;
         String reviewerName;
         String reviewerImg;
+        Integer reviewerFollowerCount;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
     }


### PR DESCRIPTION
### 📌 관련 이슈
- #42 

### 💻 작업 내용
- 팔로잉 API를 구현했습니다.
- 팔로잉/팔로워 목록 조회를 구현했습니다. 페이지네이션을 사용했습니다.
- 팔로잉/팔로워 목록 수정(취소) 기능을 구현했습니다
- 리뷰 관련 API에서 유저 id를 jwt 토큰을 이용하여 가져오도록 수정했습니다.
- 유저에 팔로워수, 팔로잉 수 칼럼을 추가했습니다. 팔로워수, 팔로잉수는 팔로우 혹은 팔로우 취소 시 자동으로 반영됩니다.
- 본인을 팔로우하거나 취소할 경우를 예외처리했습니다. 또한 팔로우 시 이미 팔로우 중인 경우, 팔로우 취소 시 팔로우 중이 아닌 경우 등도 예외 처리했습니다.

### ✍️ 추후 수정 사항
- 여행객/현지인 등급 기능이 완성되면 팔로워/팔로잉 목록 조회 시 여행객/현지인 등급도 포함할 예정입니다!
