### PR TITLE
[#43]유저 등급 API 구현

### DIFF
--- a/src/main/java/com/example/locavel/LocavelApplication.java
+++ b/src/main/java/com/example/locavel/LocavelApplication.java
@@ -3,9 +3,11 @@ package com.example.locavel;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class LocavelApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/locavel/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/locavel/apiPayload/code/status/SuccessStatus.java
@@ -20,6 +20,9 @@ public enum SuccessStatus implements BaseCode {
     USER_DELETED(HttpStatus.OK,"USER2003", "유저가 정상적으로 삭제되었습니다."),
     USER_FOUND(HttpStatus.OK,"USER2005","유저를 정상적으로 조회했습니다."),
 
+    //유저 등급
+    GRADE_GET_OK(HttpStatus.OK, "GRADE2004", "유저 등급 조회를 정상적으로 조회했습니다."),
+
     //리뷰
     REVIEW_CREATE_OK(HttpStatus.OK,"REVIEW2001", "리뷰가 정상적으로 등록되었습니다."),
     REVIEW_UPDATE_OK(HttpStatus.OK,"REVIEW2002", "리뷰가 정상적으로 수정되었습니다."),
@@ -32,8 +35,7 @@ public enum SuccessStatus implements BaseCode {
     PLACE_CREATE_OK(HttpStatus.OK, "PLACE2001", "장소가 정상적으로 등록되었습니다."),
     PLACE_GET_OK(HttpStatus.OK, "PLACE2004", "장소를 조회했습니다."),
     PLACE_LIST_GET_OK(HttpStatus.OK, "PLACE2004", "장소 목록을 조회했습니다."),
-    PLACE_MARKER_GET_OK(HttpStatus.OK, "PLACE2004", "장소 마커 정보를 조회했습니다."),
-    ;
+    PLACE_MARKER_GET_OK(HttpStatus.OK, "PLACE2004", "장소 마커 정보를 조회했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/locavel/config/SecurityConfig.java
+++ b/src/main/java/com/example/locavel/config/SecurityConfig.java
@@ -78,6 +78,9 @@ public class SecurityConfig {
                         .requestMatchers("/api/reviews/**").permitAll()
                         //TODO : 장소 관련 api 일단 모두 허용, 추후 삭제
                         .requestMatchers("/api/places/**").permitAll()
+                        //TODO : 등급 관련 api 일단 모두 허용, 추후 삭제
+                        .requestMatchers("/api/users/{user_id}/grade").permitAll()
+                        .requestMatchers("/api/users/{user_id}/grade").permitAll()
                         .anyRequest().authenticated()) // 위의 경로 이외에는 모두 인증된 사용자만 접근 가능
                 .logout(logout -> logout
                         .logoutUrl("/api/auth/logout")

--- a/src/main/java/com/example/locavel/converter/UserConverter.java
+++ b/src/main/java/com/example/locavel/converter/UserConverter.java
@@ -1,6 +1,7 @@
 package com.example.locavel.converter;
 
 import com.example.locavel.domain.User;
+import com.example.locavel.web.dto.UserDTO.UserRequestDto;
 import com.example.locavel.web.dto.UserDTO.UserResponseDto;
 import org.springframework.stereotype.Component;
 
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 public class UserConverter {
 
     public static UserResponseDto.UpdateUserProfileResultDTO updateUserProfileResultDTO(User user){
-        return UserResponseDto.UpdateUserProfileResultDTO.builder()
+        return com.example.locavel.web.dto.UserDTO.UserResponseDto.UpdateUserProfileResultDTO.builder()
                 .profileImage(user.getProfileImage())
                 .build();
     }
@@ -24,7 +25,8 @@ public class UserConverter {
                 .username(user.getUsername())
                 .nickname(user.getNickname())
                 .socialType(user.getSocialType())
-                .grade(user.getGrade())
+                .localGrade(user.getLocalGrade())
+                .travelerGrade(user.getTravelerGrade())
                 .role(user.getRole())
                 .created_at(user.getCreated_at())
                 .updated_at(user.getUpdated_at())
@@ -48,4 +50,28 @@ public class UserConverter {
                 .updated_at(LocalDateTime.now())
                 .build();
     }
+
+    //회원 등급 조회하기
+    public  UserResponseDto.GradeResponseDto toGetUserGradeDTO(User user){
+        return UserResponseDto.GradeResponseDto.builder()
+                .userId(user.getId())
+                .localGrade(user.getLocalGrade())
+                .travelerGrade(user.getTravelerGrade())
+                .build();
+    }
+
+    //회원 등급 수정하기
+    public UserResponseDto.PatchGradeResponseDto patchGradeResponseDTO(User user){
+        return UserResponseDto.PatchGradeResponseDto.builder()
+                .user_id(user.getId())
+                .localGrade(user.getLocalGrade())
+                .travelerGrade(user.getTravelerGrade())
+                .localGradeScore(user.getLocalGradeScore())
+                .travelerGradeScore(user.getTravelerGradeScore())
+                .build();
+    }
+
+
+
+
 }

--- a/src/main/java/com/example/locavel/converter/UserConverter.java
+++ b/src/main/java/com/example/locavel/converter/UserConverter.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 public class UserConverter {
 
     public static UserResponseDto.UpdateUserProfileResultDTO updateUserProfileResultDTO(User user){
-        return com.example.locavel.web.dto.UserDTO.UserResponseDto.UpdateUserProfileResultDTO.builder()
+        return UserResponseDto.UpdateUserProfileResultDTO.builder()
                 .profileImage(user.getProfileImage())
                 .build();
     }
@@ -60,16 +60,7 @@ public class UserConverter {
                 .build();
     }
 
-    //회원 등급 수정하기
-    public UserResponseDto.PatchGradeResponseDto patchGradeResponseDTO(User user){
-        return UserResponseDto.PatchGradeResponseDto.builder()
-                .user_id(user.getId())
-                .localGrade(user.getLocalGrade())
-                .travelerGrade(user.getTravelerGrade())
-                .localGradeScore(user.getLocalGradeScore())
-                .travelerGradeScore(user.getTravelerGradeScore())
-                .build();
-    }
+
 
 
 

--- a/src/main/java/com/example/locavel/domain/User.java
+++ b/src/main/java/com/example/locavel/domain/User.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -53,7 +54,25 @@ public class User extends BaseEntity {
     private String phone_num;
 
     @Enumerated(EnumType.STRING)
-    private Grade grade;
+    private Grade localGrade = Grade.IRON;
+
+    @Enumerated(EnumType.STRING)
+    private Grade travelerGrade = Grade.IRON;
+
+
+    @PrePersist
+    public void prePersist() {
+        if (localGrade == null) {
+            localGrade = Grade.IRON; // 기본값 설정
+        }
+        if (travelerGrade == null) {
+            travelerGrade = Grade.IRON; // 기본값 설정
+        }
+    }
+
+
+    private int localGradeScore; // 로컬 등급 점수
+    private int travelerGradeScore; // 여행객 등급 점수
 
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -71,6 +90,8 @@ public class User extends BaseEntity {
     private LocalDateTime deleted_at;
 
     private LocalDateTime updated_at;
+
+    private int lastCalculatedMonths;
 
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
@@ -102,4 +123,26 @@ public class User extends BaseEntity {
     public void setIntroduce(String introduce){this.introduce = introduce;}
 
     public void setPhone_num(String phone_num){this.phone_num = phone_num;}
+
+    public void setLocalGrade(Grade localGrade) {
+        this.localGrade = localGrade;
+    }
+
+
+    public void setLocalGradeScore(int localGradeScore) {
+        this.localGradeScore = localGradeScore;
+    }
+
+    public void setTravelerGradeScore(int travelerGradeScore) {
+        this.travelerGradeScore = travelerGradeScore;
+    }
+
+
+    public void setLastCalculatedMonths(int lastCalculatedMonths) {
+        this.lastCalculatedMonths = lastCalculatedMonths;
+    }
+
+    public void setTravelerGrade(Grade travelerGrade) {
+        this.travelerGrade = travelerGrade;
+    }
 }

--- a/src/main/java/com/example/locavel/domain/enums/Grade.java
+++ b/src/main/java/com/example/locavel/domain/enums/Grade.java
@@ -1,9 +1,10 @@
 package com.example.locavel.domain.enums;
 
 public enum Grade {
+    IRON,
     BRONZE,
     SILVER,
     GOLD,
-    PLATINUM,
-    DIAMOND
+    DIAMOND,
+    VIP
 }

--- a/src/main/java/com/example/locavel/repository/PlaceRepository.java
+++ b/src/main/java/com/example/locavel/repository/PlaceRepository.java
@@ -43,4 +43,5 @@ public interface PlaceRepository extends JpaRepository<Places, Long> {
     List<Places> searchByKeyword(@Param("keyword") String keyword);
 
 
+    int countByUser(User user);
 }

--- a/src/main/java/com/example/locavel/service/PlaceService.java
+++ b/src/main/java/com/example/locavel/service/PlaceService.java
@@ -9,6 +9,7 @@ import com.example.locavel.domain.enums.Category;
 import com.example.locavel.domain.enums.Region;
 import com.example.locavel.repository.PlaceImgRepository;
 import com.example.locavel.repository.PlaceRepository;
+import com.example.locavel.service.userService.UserCommandService;
 import com.example.locavel.web.dto.MapDTO.MapResponseDTO;
 import com.example.locavel.web.dto.PlaceDTO.PlaceRequestDTO;
 import jakarta.transaction.Transactional;
@@ -30,6 +31,8 @@ public class PlaceService {
     private final PlaceImgRepository placeImgRepository;
     private final S3Uploader s3Uploader;
     private final WebClient webClient;
+    @Autowired
+    private UserCommandService userCommandService; //등급 업데이트를 위해 추가
 
     @Autowired
     public PlaceService(PlaceRepository placeRepository, PlaceImgRepository placeImgRepository, S3Uploader s3Uploader, WebClient.Builder webClientBuilder) {

--- a/src/main/java/com/example/locavel/service/userService/UserCommandService.java
+++ b/src/main/java/com/example/locavel/service/userService/UserCommandService.java
@@ -1,7 +1,10 @@
 package com.example.locavel.service.userService;
 
 import com.example.locavel.domain.User;
+import com.example.locavel.domain.enums.Grade;
+import com.example.locavel.web.dto.ReviewDTO.ReviewRequestDTO;
 import com.example.locavel.web.dto.UserDTO.UserRequestDto;
+import com.example.locavel.web.dto.UserDTO.UserResponseDto;
 import com.example.locavel.web.dto.UserDTO.UserSignUpDto;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -15,4 +18,14 @@ public interface UserCommandService {
     User deleteUser(HttpServletRequest httpServletRequest);
 
     User updateUser(HttpServletRequest httpServletRequest, UserRequestDto.UpdateUserDTO updateUserDTO);
+
+    User getUserGrade(Long userId);
+
+    User updateLocalGrade(Long userId);
+
+    void updateMemberScoresDaily();
+
+    User calculateTravelerGradeScore(Long userId, ReviewRequestDTO.RevieweDTO request);
+
+    Grade calculateLocalGrade(int score);
 }

--- a/src/main/java/com/example/locavel/service/userService/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/locavel/service/userService/UserCommandServiceImpl.java
@@ -1,20 +1,31 @@
 package com.example.locavel.service.userService;
 
 import com.example.locavel.apiPayload.code.status.ErrorStatus;
+import com.example.locavel.converter.UserConverter;
 import com.example.locavel.domain.User;
 import com.example.locavel.domain.enums.Access;
 import com.example.locavel.apiPayload.exception.handler.UserHandler;
+import com.example.locavel.domain.enums.Grade;
+import com.example.locavel.repository.PlaceRepository;
+import com.example.locavel.repository.ReviewRepository;
 import com.example.locavel.repository.UserRepository;
 import com.example.locavel.service.jwtService.JwtService;
+import com.example.locavel.web.controller.UserController;
+import com.example.locavel.web.dto.PlaceDTO.PlaceRequestDTO;
+import com.example.locavel.web.dto.ReviewDTO.ReviewRequestDTO;
 import com.example.locavel.web.dto.UserDTO.UserRequestDto;
+import com.example.locavel.web.dto.UserDTO.UserResponseDto;
 import com.example.locavel.web.dto.UserDTO.UserSignUpDto;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 @Service
 @Transactional
@@ -23,7 +34,9 @@ public class UserCommandServiceImpl implements UserCommandService{
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;//PasswordEncoder 구현체 Spring Bean 등록으로 해결
+    private final ReviewRepository reviewRepository;
     private final JwtService jwtService;
+    private final PlaceRepository placeRepository;
 
     public void signUp(UserSignUpDto userSignUpDto) throws Exception{
 
@@ -94,4 +107,97 @@ public class UserCommandServiceImpl implements UserCommandService{
         if(updateUserDTO.getPhone_num() != null) user.setPhone_num(updateUserDTO.getPhone_num());
         return user;
     }
-}
+
+    @Override
+    public User getUserGrade(Long userId){
+        User user = userRepository.findById(userId)
+
+                .orElseThrow(() ->  new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        return user;
+    }
+
+    @Override
+    public User updateLocalGrade(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        int localScore = user.getLocalGradeScore(); //user의 로컬 점수를 가져옴
+        localScore += 15; //15점 증가시킴
+        user.setLocalGradeScore(localScore); //로컬 점수를 저장
+        Grade localGrade = calculateLocalGrade(localScore); //로컬 점수를 통해 로컬 등급을 계산
+        user.setLocalGrade(localGrade);//로컬 등급을 저장
+        user = userRepository.save(user);//db에 저장하기
+
+        return user;
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정에 실행
+    @Override
+    public void updateMemberScoresDaily() {
+        List<User> users = userRepository.findAll(); // 모든 회원 조회
+
+        for (User user : users) {
+            LocalDateTime certifiedAt = user.getCertified_at();
+            if (certifiedAt != null) {
+                // 인증된 날짜와 현재 날짜 사이의 차이를 계산
+                long daysPassed = ChronoUnit.DAYS.between(certifiedAt, LocalDateTime.now());
+
+                // 점수가 이미 계산된 마지막 날짜를 기준으로 경과한 30일 단위로 점수 부여
+                long monthsPassed = daysPassed / 30; // 경과한 30일 단위 개수 계산
+                if (monthsPassed > user.getLastCalculatedMonths()) {
+                    int additionalScore = (int) ((monthsPassed - user.getLastCalculatedMonths()) * 10);
+                    user.setLocalGradeScore(user.getLocalGradeScore() + additionalScore);
+                    user.setLastCalculatedMonths((int) monthsPassed); // 마지막 계산된 개월 수 업데이트
+                }
+
+                // 업데이트 된 점수를 바탕으로 등급 계산
+                Grade newGrade = calculateLocalGrade(user.getLocalGradeScore());
+                user.setLocalGrade(newGrade); // 등급 업데이트
+
+                // 변경 사항 저장
+                userRepository.save(user);
+            }
+        }
+    }
+
+    @Override
+    public User calculateTravelerGradeScore (Long userId, ReviewRequestDTO.RevieweDTO request){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        int travelerScore = user.getTravelerGradeScore(); //user의 여행객 점수를 가져옴
+        travelerScore += 10; //별점으로 인한 10점 증가
+
+        if (!request.getComment().isEmpty()) {
+            travelerScore += 15; // comment가 있을 경우 추가로 15점 더하기
+        }
+        user.setTravelerGradeScore(travelerScore); //로컬 점수를 저장
+        Grade travelerGrade = calculateLocalGrade(travelerScore); //로컬 점수를 통해 로컬 등급을 계산
+        user.setTravelerGrade(travelerGrade);//로컬 등급을 저장
+        user = userRepository.save(user);//db에 저장하기
+
+        return user;
+        }
+
+    @Override
+    @Transactional
+    public Grade calculateLocalGrade ( int score){
+            if (score < 50) {
+                return Grade.IRON;
+            } else if (score < 100) {
+                return Grade.BRONZE;
+            } else if (score<300) {
+                return Grade.SILVER;
+            } else if (score<500) {
+                return Grade.GOLD;
+            } else if (score<1000){
+                return Grade.DIAMOND;
+            }
+            else {
+                return Grade.VIP;
+            }
+        }
+    }
+
+

--- a/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
@@ -9,6 +9,7 @@ import com.example.locavel.domain.Places;
 import com.example.locavel.domain.Reviews;
 import com.example.locavel.service.PlaceService;
 import com.example.locavel.service.ReviewService;
+import com.example.locavel.service.userService.UserCommandService;
 import com.example.locavel.web.dto.PlaceDTO.PlaceRequestDTO;
 import com.example.locavel.web.dto.PlaceDTO.PlaceResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +31,7 @@ public class PlaceRestController {
 
     private final PlaceService placeService;
     private final ReviewService reviewService;
+    private final UserCommandService userCommandService;
 
     @GetMapping("/api/places/{placeId}")
     @Operation(summary = "특정 장소 상세 조회 API", description = "특정 장소를 상세 조회하는 API입니다. query String으로 place 번호를 주세요")
@@ -54,6 +56,8 @@ public class PlaceRestController {
         }
         Places place = placeService.createPlace(placeDTO, placeImgUrls);
         if(place == null) {throw new PlacesHandler(ErrorStatus.ADDRESS_NOT_VALID);}
+        Long userId = placeDTO.getUserId(); // DTO에서 userId를 가져옵니다.
+        userCommandService.updateLocalGrade(userId);
         return ApiResponse.of(SuccessStatus.PLACE_CREATE_OK, PlaceConverter.toPlaceResultDTO(place));
     }
 

--- a/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/ReviewRestController.java
@@ -8,6 +8,7 @@ import com.example.locavel.converter.ReviewConverter;
 import com.example.locavel.domain.Reviews;
 import com.example.locavel.domain.enums.Traveler;
 import com.example.locavel.service.ReviewService;
+import com.example.locavel.service.userService.UserCommandService;
 import com.example.locavel.web.dto.ReviewDTO.ReviewRequestDTO;
 import com.example.locavel.web.dto.ReviewDTO.ReviewResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,6 +28,7 @@ import java.util.List;
 public class ReviewRestController {
     private final ReviewService reviewService;
     private final ReviewConverter reviewConverter;
+    private final UserCommandService userCommandService;
 
     @Operation(summary = "리뷰 등록", description = "리뷰를 등록합니다.")
     @PostMapping(value = "/{placeId}", consumes = "multipart/form-data")
@@ -41,6 +43,8 @@ public class ReviewRestController {
             throw new ReviewsHandler(ErrorStatus.RATING_NOT_VALID);
         }
         ReviewResponseDTO.ReviewResultDTO response = reviewService.createReview(placeId, request, reviewImgUrls);
+        Long userId = request.getUserId();
+        userCommandService.calculateTravelerGradeScore(userId ,request); //여행객 점수를 증가시키는 로직
         return ApiResponse.of(SuccessStatus.REVIEW_CREATE_OK,response);
     }
 

--- a/src/main/java/com/example/locavel/web/controller/UserController.java
+++ b/src/main/java/com/example/locavel/web/controller/UserController.java
@@ -13,9 +13,11 @@ import com.example.locavel.web.dto.TermDTO.TermResponseDTO;
 import com.example.locavel.web.dto.UserDTO.UserRequestDto;
 import com.example.locavel.web.dto.UserDTO.UserResponseDto;
 import com.example.locavel.web.dto.UserDTO.UserSignUpDto;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationProperties;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -69,4 +71,15 @@ public class UserController {
         List<TermAgreement> agree = termService.agree(termAgreeDTO);
         return ApiResponse.of(SuccessStatus.USER_TERM_AGREED, TermConverter.toTermAgreeResultDTO(agree));
     }
+
+    //유저 등급 조회
+    @Operation(summary = "유저 등급 조회", description = "유저의 등급을 조회합니다.")
+    @GetMapping("/api/users/{userId}/grade")
+    public ApiResponse<UserResponseDto.GradeResponseDto> getUserGrade(@PathVariable Long userId ){
+        User user = userCommandService.getUserGrade(userId);
+        UserResponseDto.GradeResponseDto response = userConverter.toGetUserGradeDTO(user);
+        return ApiResponse.of(SuccessStatus.GRADE_GET_OK, response);
+    }
+
+
 }

--- a/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceRequestDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceRequestDTO.java
@@ -11,6 +11,7 @@ public class PlaceRequestDTO {
     public static class PlaceDTO {
         @NotNull
         String name;
+        Long userId;
         String address;
         String category;
         String telephoneNumber;

--- a/src/main/java/com/example/locavel/web/dto/UserDTO/UserRequestDto.java
+++ b/src/main/java/com/example/locavel/web/dto/UserDTO/UserRequestDto.java
@@ -1,6 +1,7 @@
 package com.example.locavel.web.dto.UserDTO;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -18,4 +19,7 @@ public class UserRequestDto {
         private String introduce;
         private String phone_num;
     }
+
+
+
 }

--- a/src/main/java/com/example/locavel/web/dto/UserDTO/UserResponseDto.java
+++ b/src/main/java/com/example/locavel/web/dto/UserDTO/UserResponseDto.java
@@ -3,10 +3,7 @@ package com.example.locavel.web.dto.UserDTO;
 import com.example.locavel.domain.enums.Grade;
 import com.example.locavel.domain.enums.Role;
 import com.example.locavel.domain.enums.SocialType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
@@ -34,7 +31,8 @@ public class UserResponseDto {
         private String introduce;
         private String phone_num;
         private String profileImage;
-        private Grade grade;
+        private Grade localGrade;
+        private Grade travelerGrade;
         private Role role;
         private LocalDateTime created_at;
         private LocalDateTime updated_at;
@@ -61,5 +59,27 @@ public class UserResponseDto {
         private String phone_num;
         private LocalDateTime updated_at;
 
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GradeResponseDto {
+        private Long userId;
+        private Grade localGrade;
+        private Grade travelerGrade;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PatchGradeResponseDto {
+        private Long user_id;
+        private Grade localGrade;
+        private Grade travelerGrade;
+        private int localGradeScore;   // 로컬 등급 점수
+        private int travelerGradeScore; // 여행객 등급 점수
     }
 }

--- a/src/main/java/com/example/locavel/web/dto/UserDTO/UserResponseDto.java
+++ b/src/main/java/com/example/locavel/web/dto/UserDTO/UserResponseDto.java
@@ -71,15 +71,4 @@ public class UserResponseDto {
         private Grade travelerGrade;
     }
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class PatchGradeResponseDto {
-        private Long user_id;
-        private Grade localGrade;
-        private Grade travelerGrade;
-        private int localGradeScore;   // 로컬 등급 점수
-        private int travelerGradeScore; // 여행객 등급 점수
-    }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- #43 

### 💻 작업 내용
- 유저 등급 조회를 구현했습니다.
- Grade의 enum값을 IRON, BRONZE, SILVER, GOLD, DIAMOND, VIP 다음과 같이 변경하였습니다.
- 유저 등급 부여에 대해서는 enum값 IRON을 기본값으로 설정하였습니다.
- 기존의 userEntity에서 등급을 나타내는 Grade -> localGrade, travelerGrade 두개로 나누었습니다.
- 현지 유저 등급 변경에 대해서는 장소 api를 작성할때, localGradeScore 15점을 부여하도록 했습니다. (PlaceController, UserCommandService에 관련 내용)
- 또한 현지 유저의 지역 인증 기간에 대해서는 @Scheduled를 이용해 지역 인증 날짜certified_at과 현재 시간을 비교하여 1달이 지날때마다 점수부여 10점을 할 수 있도록 했습니다. 
- 여행객 유저 등급 변경에 대해서는 리뷰 api를 작성할 때, travelerGradeScore 별점으로 인해 10점 부여, comment가 ""이 아닐경우 15점을 부여할 수 있도록 하였습니다.(ReviewController, UserCommandService에 관련 내용)
