### PR TITLE
[#47] 위시리스트 관련 기능 구현

### DIFF
--- a/src/main/java/com/example/locavel/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/locavel/apiPayload/code/status/ErrorStatus.java
@@ -49,6 +49,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // 지역
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION4001", "해당하는 지역이 존재하지 않습니다"),
 
+    //위시리스트
+    WISHLIST_ALREADY_ADDED(HttpStatus.BAD_REQUEST,"WISHLIST4001","이미 위시리스트에 저장되어있습니다."),
+    WISHLIST_NOT_FOUND(HttpStatus.NOT_FOUND,"WISHLIST4002","위시리스트에 저장되어 있지 않습니다."),
+
+
     //약관 동의
     TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "약관 동의가 존재하지 않습니다.");
 

--- a/src/main/java/com/example/locavel/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/locavel/apiPayload/code/status/SuccessStatus.java
@@ -41,6 +41,11 @@ public enum SuccessStatus implements BaseCode {
     FOLLOW_OK(HttpStatus.OK, "FOLLOW2001", "팔로우가 완료되었습니다."),
     FOLLOW_DELETE_OK(HttpStatus.OK,"FOLLOW2002","팔로우 취소가 완료되었습니다."),
     FOLLOW_GET_OK(HttpStatus.OK,"FOLLOW2003","팔로우 목록을 조회했습니다."),
+
+    //위시리스트
+    WISHLIST_ADD_OK(HttpStatus.OK,"WISHLIST2001","위시리스트에 저장되었습니다."),
+    WISHLIST_DELETE_OK(HttpStatus.OK,"WISHLIST2002","위시리스트에서 삭제되었습니다."),
+    WISHLIST_GET_OK(HttpStatus.OK,"WISHLIST2003","위시리스트를 조회했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/locavel/converter/FollowConverter.java
+++ b/src/main/java/com/example/locavel/converter/FollowConverter.java
@@ -20,7 +20,8 @@ public class FollowConverter {
                 .nickname(user.getNickname())
                 .profile(user.getProfileImage())
                 .userId(user.getId())
-                //TODO:등급추가
+                .localGrade(user.getLocalGrade())
+                .travelerGrade(user.getTravelerGrade())
                 .build();
     }
 

--- a/src/main/java/com/example/locavel/converter/PlaceConverter.java
+++ b/src/main/java/com/example/locavel/converter/PlaceConverter.java
@@ -1,13 +1,10 @@
 package com.example.locavel.converter;
 
-import com.example.locavel.domain.PlaceImg;
-import com.example.locavel.domain.Places;
-import com.example.locavel.domain.Region;
-import com.example.locavel.domain.Reviews;
-import com.example.locavel.domain.ReviewImg;
+import com.example.locavel.domain.*;
 import com.example.locavel.domain.enums.Category;
 import com.example.locavel.web.dto.PlaceDTO.PlaceRequestDTO;
 import com.example.locavel.web.dto.PlaceDTO.PlaceResponseDTO;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -159,5 +156,34 @@ public class PlaceConverter {
         return placesList.stream()
                 .map(PlaceConverter::toSearchResultPlaceDTO)
                 .collect(Collectors.toList());
+    }
+    public static WishList toWishList(User user, Places place) {
+        return WishList.builder()
+                .user(user)
+                .place(place)
+                .build();
+    }
+    public static PlaceResponseDTO.WishPlaceDTO toWishPlaceDTO(Places place) {
+        return PlaceResponseDTO.WishPlaceDTO.builder()
+                .description(place.getDescription())
+                .totalRating(place.getRating())
+                .generalRating(place.getGeneralRating())
+                .travelerRating(place.getTravelerRating())
+                .name(place.getName())
+                .placeId(place.getId())
+                .build();
+    }
+
+    public static PlaceResponseDTO.WishPlaceListDTO toWishPlaceListDTO(Page<Places> placeList) {
+        List<PlaceResponseDTO.WishPlaceDTO> wishPlaceDTOList = placeList.stream()
+                .map(PlaceConverter::toWishPlaceDTO).collect(Collectors.toList());
+        return PlaceResponseDTO.WishPlaceListDTO.builder()
+                .wishPlaceDTOList(wishPlaceDTOList)
+                .listSize(placeList.getSize())
+                .isLast(placeList.isLast())
+                .isFirst(placeList.isFirst())
+                .totalPage(placeList.getTotalPages())
+                .totalElements(placeList.getTotalElements())
+                .build();
     }
 }

--- a/src/main/java/com/example/locavel/converter/ReviewConverter.java
+++ b/src/main/java/com/example/locavel/converter/ReviewConverter.java
@@ -35,6 +35,15 @@ public class ReviewConverter {
                 .rating(request.getRating())
                 .build();
     }
+    public static Reviews toReviews(User user, Traveler traveler, Places place, Float rating) {
+        return Reviews.builder()
+                .comment(null)
+                .user(user)
+                .traveler(traveler)
+                .place(place)
+                .rating(rating)
+                .build();
+    }
     public static ReviewImg toReviewImg(Reviews reviews, String url) {
         return ReviewImg.builder()
                 .reviews(reviews)
@@ -110,20 +119,14 @@ public class ReviewConverter {
                 .build();
     }
 
-    public static ReviewResponseDTO.placeReviewSummaryDTO toPlaceReviewSummaryDTO(
-            Float totalRating,
-            Long totalReviewCount,
-            Float generalRating,
-            Long generalReviewCount,
-            Float travelerRating,
-            Long travelerReviewCount) {
+    public static ReviewResponseDTO.placeReviewSummaryDTO toPlaceReviewSummaryDTO(Places place) {
         return ReviewResponseDTO.placeReviewSummaryDTO.builder()
-                .totalRating(totalRating)
-                .totalReviewCount(totalReviewCount)
-                .generalRating(generalRating)
-                .generalReviewCount(generalReviewCount)
-                .travelerRating(travelerRating)
-                .travelerReviewCount(travelerReviewCount)
+                .totalRating(place.getRating())
+                .totalReviewCount(place.getReviewCount())
+                .generalRating(place.getGeneralRating())
+                .generalReviewCount(place.getGeneralReviewCount())
+                .travelerRating(place.getTravelerRating())
+                .travelerReviewCount(place.getTravelerReviewCount())
                 .build();
     }
 
@@ -147,7 +150,6 @@ public class ReviewConverter {
                 .reviewerFollowerCount(user.getFollowerCount())
                 .build();
     }
-
     private final ReviewImgRepository reviewImgRepository;
     public List<String> getAllReviewImgUrls(Reviews review) {
         List<ReviewImg> reviewImgList = reviewImgRepository.findAllByReviews(review);

--- a/src/main/java/com/example/locavel/domain/Places.java
+++ b/src/main/java/com/example/locavel/domain/Places.java
@@ -54,4 +54,16 @@ public class Places extends BaseEntity {
 
     @OneToMany(mappedBy = "place")
     private List<Reviews> reviewList = new ArrayList<>();
+    @Builder.Default
+    private Float generalRating = 0f; //현지인 총점
+    @Builder.Default
+    private Float travelerRating = 0f; //여행객 총점
+    @Builder.Default
+    private Long reviewCount = 0L;
+    @Builder.Default
+    private Long generalReviewCount = 0L;
+    @Builder.Default
+    private Long travelerReviewCount = 0L;
+    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL)
+    private List<WishList> wishLists = new ArrayList<>();
 }

--- a/src/main/java/com/example/locavel/domain/User.java
+++ b/src/main/java/com/example/locavel/domain/User.java
@@ -12,7 +12,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -106,6 +105,8 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserRegion> userRegionList = new ArrayList<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<WishList> wishLists = new ArrayList<>();
 
     //유저 권한 GUEST -> USER 로
     public void authorizeUser(){

--- a/src/main/java/com/example/locavel/domain/WishList.java
+++ b/src/main/java/com/example/locavel/domain/WishList.java
@@ -1,0 +1,24 @@
+package com.example.locavel.domain;
+
+import com.example.locavel.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+public class WishList extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private Places place;
+}

--- a/src/main/java/com/example/locavel/repository/PlaceImgRepository.java
+++ b/src/main/java/com/example/locavel/repository/PlaceImgRepository.java
@@ -3,10 +3,13 @@ package com.example.locavel.repository;
 import com.example.locavel.domain.PlaceImg;
 import com.example.locavel.domain.Places;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PlaceImgRepository extends JpaRepository<PlaceImg, Long> {
     List<PlaceImg> findAllByPlaces(Places places);
-
+    @Query("select pi.imgUrl from PlaceImg pi where pi.places = :places order by pi.id desc limit 1")
+    String findPlaceImgByPlaces(@Param("places") Places places);
 }

--- a/src/main/java/com/example/locavel/repository/UserRegionRepository.java
+++ b/src/main/java/com/example/locavel/repository/UserRegionRepository.java
@@ -1,8 +1,15 @@
 package com.example.locavel.repository;
 
+import com.example.locavel.domain.User;
 import com.example.locavel.domain.mapping.UserRegion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface UserRegionRepository extends JpaRepository<UserRegion, Long> {
     public UserRegion findByUserIdAndRegionId(Long userId, Long regionId);
+    @Query("select ur.region.id from UserRegion ur where ur.user = :user")
+    List<Long> findUserRegionIdByUser(@Param("user") User user);
 }

--- a/src/main/java/com/example/locavel/repository/WishListRepository.java
+++ b/src/main/java/com/example/locavel/repository/WishListRepository.java
@@ -1,0 +1,33 @@
+package com.example.locavel.repository;
+
+import com.example.locavel.domain.Places;
+import com.example.locavel.domain.User;
+import com.example.locavel.domain.WishList;
+import com.example.locavel.domain.enums.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface WishListRepository extends JpaRepository<WishList, Long> {
+    WishList findByUserAndPlace(User user, Places place);
+    @Query("SELECT w.place FROM WishList w WHERE w.user = :user")
+    Page<Places> findAllPlacesByUser(@Param("user") User user, PageRequest pageRequest);
+    @Query("SELECT w.place " +
+            "FROM WishList w " +
+            "WHERE w.user = :user and w.place.category = :category and w.place.region.id = :regionId")
+    Page<Places> findAllPlacesByUserAndCategoryInUserRegion(@Param("user") User user, @Param("category") Category category, @Param("regionId")Long regionId, PageRequest pageRequest);
+    @Query("SELECT w.place " +
+            "FROM WishList w " +
+            "WHERE w.user = :user and w.place.category = :category and w.place.region.id IN :regionIds")
+    Page<Places> findAllPlacesByUserAndCategoryInInterest(@Param("user") User user, @Param("category") Category category, @Param("regionIds") List<Long> regionIds, PageRequest pageRequest);
+    @Query("SELECT w.place " +
+            "FROM WishList w " +
+            "WHERE w.user = :user and w.place.category = :category " +
+            "and w.place.region.id not IN :regionIds and w.place.region.id != :regionId")
+    Page<Places> findAllPlacesByUserAndCategoryInEct(@Param("user") User user, @Param("category") Category category, @Param("regionId")Long regionId, @Param("regionIds") List<Long> regionIds, PageRequest pageRequest);
+
+}

--- a/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
@@ -61,6 +61,9 @@ public class PlaceRestController {
         User user = userCommandService.getUser(httpServletRequest);
         Long userId = user.getId();
         userCommandService.updateLocalGrade(userId);
+        Reviews placeCreateReview = ReviewConverter.toReviews(user, Traveler.of(place,user),place,placeDTO.getRating());
+        reviewService.saveReview(placeCreateReview);
+        placeService.setReview(place);
         return ApiResponse.of(SuccessStatus.PLACE_CREATE_OK, PlaceConverter.toPlaceResultDTO(place));
     }
 

--- a/src/main/java/com/example/locavel/web/dto/FollowDTO/FollowResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/FollowDTO/FollowResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.locavel.web.dto.FollowDTO;
 
+import com.example.locavel.domain.enums.Grade;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,9 +29,8 @@ public class FollowResponseDTO {
         Long userId;
         String profile;
         String nickname;
-        //TODO : 등급 기능 추가 후 등급 추가
-//        Grade generalGrade;
-//        Grade travelerGrade;
+        Grade localGrade;
+        Grade travelerGrade;
 
     }
 }

--- a/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceResponseDTO.java
@@ -2,7 +2,6 @@ package com.example.locavel.web.dto.PlaceDTO;
 
 import lombok.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -97,6 +96,30 @@ public class PlaceResponseDTO {
         int reviewCount;
         List<String> reviewImgList;
     }
-
-
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WishPlaceListDTO {
+        List<WishPlaceDTO> wishPlaceDTOList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Setter
+    public static class WishPlaceDTO {
+        Long placeId;
+        String name;
+        String placeImg;
+        String description;
+        Float totalRating; // 리뷰 총점
+        Float generalRating; // 현지인 리뷰 총점
+        Float travelerRating; // 여행객 리뷰 총점
+    }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- #47 

### 💻 작업 내용
- 위시리스트 추가, 삭제,  조회를 구현했습니다.
- 위시리스트 조회 시, 페이지네이션을 사용했고, 푸드/스팟/액티비티별 + 내지역/관심지역/그외지역별 필터를 적용하여 Place 목록을 조회할 수 있도록 구현했습니다.
- 위시리스트 추가시 이미 저장된 경우, 삭제시 위시리스트에 저장되어 있지 않은 경우를 예외처리했습니다. 

### ✍️ 수정 사항
- 장소 등록시 입력하는 평점 또한 장소를 등록하는 유저의 내 지역에 따라서 현지인/여행객으로 구분하여 리뷰로 저장하도록 수정했습니다.
- 팔로잉/팔로워 목록 조회시 유저의 현지인/여행객 등급을 응답에 포함하도록 수정했습니다.
- Places 엔티티에 총 리뷰 개수, 총 리뷰 평점, 현지인 리뷰 개수, 현지인 리뷰 평점, 여행객 리뷰 개수, 여행객 리뷰 총점 필드를 추가했습니다. 리뷰 등록, 수정, 삭제 시 자동으로 반영됩니다.