### PR TITLE
[#56] 마이페이지 관련 API 구현

### DIFF
--- a/src/main/java/com/example/locavel/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/locavel/apiPayload/code/status/SuccessStatus.java
@@ -46,6 +46,11 @@ public enum SuccessStatus implements BaseCode {
     WISHLIST_ADD_OK(HttpStatus.OK,"WISHLIST2001","위시리스트에 저장되었습니다."),
     WISHLIST_DELETE_OK(HttpStatus.OK,"WISHLIST2002","위시리스트에서 삭제되었습니다."),
     WISHLIST_GET_OK(HttpStatus.OK,"WISHLIST2003","위시리스트를 조회했습니다."),
+
+    //마이페이지
+    MYPAGE_PROFILE_GET_OK(HttpStatus.OK,"MYPAGE2001","유저 프로필을 조회했습니다."),
+    MYPAGE_VISIT_GET_OK(HttpStatus.OK,"MYPAGE2002","유저가 방문한 곳을 조회했습니다."),
+    MYPATE_CALENDAR_GET_OK(HttpStatus.OK,"MYPAGE2003","유저가 방문한 날짜를 조회했습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/locavel/converter/PlaceConverter.java
+++ b/src/main/java/com/example/locavel/converter/PlaceConverter.java
@@ -163,8 +163,8 @@ public class PlaceConverter {
                 .place(place)
                 .build();
     }
-    public static PlaceResponseDTO.WishPlaceDTO toWishPlaceDTO(Places place) {
-        return PlaceResponseDTO.WishPlaceDTO.builder()
+    public static PlaceResponseDTO.PlacePreviewDTO toPlacePreviewDTO(Places place) {
+        return PlaceResponseDTO.PlacePreviewDTO.builder()
                 .description(place.getDescription())
                 .totalRating(place.getRating())
                 .generalRating(place.getGeneralRating())
@@ -174,11 +174,11 @@ public class PlaceConverter {
                 .build();
     }
 
-    public static PlaceResponseDTO.WishPlaceListDTO toWishPlaceListDTO(Page<Places> placeList) {
-        List<PlaceResponseDTO.WishPlaceDTO> wishPlaceDTOList = placeList.stream()
-                .map(PlaceConverter::toWishPlaceDTO).collect(Collectors.toList());
-        return PlaceResponseDTO.WishPlaceListDTO.builder()
-                .wishPlaceDTOList(wishPlaceDTOList)
+    public static PlaceResponseDTO.PlacePreviewListDTO toPlacePreviewListDTO(Page<Places> placeList) {
+        List<PlaceResponseDTO.PlacePreviewDTO> placePreviewDTOList = placeList.stream()
+                .map(PlaceConverter::toPlacePreviewDTO).collect(Collectors.toList());
+        return PlaceResponseDTO.PlacePreviewListDTO.builder()
+                .PlacePreviewDTOList(placePreviewDTOList)
                 .listSize(placeList.getSize())
                 .isLast(placeList.isLast())
                 .isFirst(placeList.isFirst())

--- a/src/main/java/com/example/locavel/converter/UserConverter.java
+++ b/src/main/java/com/example/locavel/converter/UserConverter.java
@@ -1,11 +1,13 @@
 package com.example.locavel.converter;
 
 import com.example.locavel.domain.User;
-import com.example.locavel.web.dto.UserDTO.UserRequestDto;
 import com.example.locavel.web.dto.UserDTO.UserResponseDto;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class UserConverter {
@@ -60,9 +62,26 @@ public class UserConverter {
                 .build();
     }
 
-
-
-
-
-
+    public UserResponseDto.UserProfileDTO toUserProfileDTO(User user){
+        return UserResponseDto.UserProfileDTO.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .follower(user.getFollowerCount())
+                .following(user.getFollowingCount())
+                .travelerGrade(user.getTravelerGrade())
+                .localGrade(user.getLocalGrade())
+                .imgUrl(user.getProfileImage())
+                .reviewCount(user.getReviewCount())
+                .introduce(user.getIntroduce())
+                .build();
+    }
+    public static UserResponseDto.VisitCalendarDTO toVisitCalendarDTO(List<LocalDateTime> reviewDayList) {
+        List<LocalDate> dayList = reviewDayList.stream()
+                .map(LocalDateTime::toLocalDate)
+                .distinct()
+                .collect(Collectors.toList());
+        return UserResponseDto.VisitCalendarDTO.builder()
+                .visitDayList(dayList)
+                .build();
+    }
 }

--- a/src/main/java/com/example/locavel/domain/User.java
+++ b/src/main/java/com/example/locavel/domain/User.java
@@ -94,6 +94,8 @@ public class User extends BaseEntity {
     private Integer followingCount = 0;
     @Builder.Default
     private Integer followerCount = 0;
+    @Builder.Default
+    private Integer reviewCount = 0;
 
     private int lastCalculatedMonths;
 
@@ -168,5 +170,7 @@ public class User extends BaseEntity {
     public void setFollowerCountPlus(){this.followerCount++;}
     public void setFollowingCountMinus(){this.followingCount--;}
     public void setFollowerCountMinus(){this.followerCount--;}
+    public void setReviewCountPlus(){this.reviewCount++;}
+    public void setReviewCountMinus(){this.reviewCount--;}
 
 }

--- a/src/main/java/com/example/locavel/repository/ReviewRepository.java
+++ b/src/main/java/com/example/locavel/repository/ReviewRepository.java
@@ -3,6 +3,7 @@ package com.example.locavel.repository;
 import com.example.locavel.domain.Places;
 import com.example.locavel.domain.Reviews;
 import com.example.locavel.domain.User;
+import com.example.locavel.domain.enums.Category;
 import com.example.locavel.domain.enums.Traveler;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -11,6 +12,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Reviews, Long>, JpaSpecificationExecutor<Reviews> {
@@ -25,4 +27,14 @@ public interface ReviewRepository extends JpaRepository<Reviews, Long>, JpaSpeci
     Float getAvgRatingByPlaceAndTraveler(@Param("placeId")Long placeId, @Param("traveler")Traveler traveler);
 
     List<Reviews> findAllByPlace(Places places);
+
+    @Query("select r.place from Reviews r where r.user = :user")
+    Page<Places> findAllPlaceByUser(@Param("user") User user, PageRequest pageRequest);
+
+    @Query("select r.created_at from Reviews r where r.user = :user and r.created_at >= :start and r.created_at <= :end")
+    List<LocalDateTime> findAllCreatedAtByDate(@Param("user")User user, @Param("start")LocalDateTime start, @Param("end")LocalDateTime end);
+
+    @Query("select r.created_at from Reviews r where r.user = :user and r.created_at >= :start and r.created_at <= :end and r.place.category = :category")
+    List<LocalDateTime> findAllCreatedAtByDateAndCategory(@Param("user")User user, @Param("start")LocalDateTime start, @Param("end")LocalDateTime end, @Param("category")Category category);
+
 }

--- a/src/main/java/com/example/locavel/service/PlaceService.java
+++ b/src/main/java/com/example/locavel/service/PlaceService.java
@@ -36,11 +36,20 @@ public class PlaceService {
     private final WishListRepository wishListRepository;
     private final ReviewRepository reviewRepository;
     private final UserRegionRepository userRegionRepository;
+    private final UserRepository userRepository;
     @Autowired
     private UserCommandService userCommandService; //등급 업데이트를 위해 추가
 
     @Autowired
-    public PlaceService(PlaceRepository placeRepository, PlaceImgRepository placeImgRepository, S3Uploader s3Uploader, WebClient.Builder webClientBuilder, RegionService regionService, WishListRepository wishListRepository, ReviewRepository reviewRepository, UserRegionRepository userRegionRepository) {
+    public PlaceService(PlaceRepository placeRepository,
+                        PlaceImgRepository placeImgRepository,
+                        S3Uploader s3Uploader,
+                        WebClient.Builder webClientBuilder,
+                        RegionService regionService,
+                        WishListRepository wishListRepository,
+                        ReviewRepository reviewRepository,
+                        UserRegionRepository userRegionRepository,
+                        UserRepository userRepository) {
         this.placeRepository = placeRepository;
         this.placeImgRepository = placeImgRepository;
         this.s3Uploader = s3Uploader;
@@ -49,6 +58,7 @@ public class PlaceService {
         this.wishListRepository = wishListRepository;
         this.reviewRepository = reviewRepository;
         this.userRegionRepository = userRegionRepository;
+        this.userRepository = userRepository;
     }
 
 
@@ -74,6 +84,9 @@ public class PlaceService {
         if(placeImgUrls != null && !placeImgUrls.isEmpty()) {
             uploadPlaceImg(placeImgUrls, place, false);
         }
+        User user = place.getUser();
+        user.setReviewCountPlus();
+        userRepository.save(user);
         return placeRepository.save(place);
 
     }
@@ -172,7 +185,11 @@ public class PlaceService {
         else if(region.equals("etc")) {
             wishPlaceList = wishListRepository.findAllPlacesByUserAndCategoryInEct(user, cat,  regionId, interestRegionIdList, PageRequest.of(page, 10));
         }
-        return PlaceConverter.toWishPlaceListDTO(wishPlaceList);
+        return PlaceConverter.toPlacePreviewListDTO(wishPlaceList);
+    }
+    public PlaceResponseDTO.PlacePreviewListDTO getUserVisitPlaceList(User user, Integer page) {
+        Page<Places> visitPlaceList = reviewRepository.findAllPlaceByUser(user,PageRequest.of(page,10));
+        return PlaceConverter.toPlacePreviewListDTO(visitPlaceList);
     }
     public void setReview(Places place) { //리뷰정보 업데이트
         Long placeId = place.getId();

--- a/src/main/java/com/example/locavel/service/PlaceService.java
+++ b/src/main/java/com/example/locavel/service/PlaceService.java
@@ -157,7 +157,7 @@ public class PlaceService {
             throw new PlacesHandler(ErrorStatus.WISHLIST_NOT_FOUND);
         }
     }
-    public PlaceResponseDTO.WishPlaceListDTO getWishPlaceList(User user, String category, String region, Integer page) {
+    public PlaceResponseDTO.PlacePreviewListDTO getWishPlaceList(User user, String category, String region, Integer page) {
         Page<Places> wishPlaceList = null;
         Category cat = Category.valueOf(category.toLowerCase());
         Region userRegion = regionService.findRegion(user.getLocation());
@@ -195,7 +195,7 @@ public class PlaceService {
         place.setGeneralRating(generalRating);
         place.setGeneralReviewCount(generalCount);
     }
-    public PlaceResponseDTO.WishPlaceDTO setPlaceImg(PlaceResponseDTO.WishPlaceDTO wishPlaceDTO){
+    public PlaceResponseDTO.PlacePreviewDTO setPlaceImg(PlaceResponseDTO.PlacePreviewDTO wishPlaceDTO){
         Places place = placeRepository.findById(wishPlaceDTO.getPlaceId())
                 .orElseThrow(()->new PlacesHandler(ErrorStatus.PLACE_NOT_FOUND));
         String imgUrl = placeImgRepository.findPlaceImgByPlaces(place);

--- a/src/main/java/com/example/locavel/service/ReviewService.java
+++ b/src/main/java/com/example/locavel/service/ReviewService.java
@@ -139,4 +139,20 @@ public class ReviewService {
     public void saveReview(Reviews review) {
         reviewRepository.save(review);
     }
+    public UserResponseDto.VisitCalendarDTO getVisitDayList(User user, Integer year, Integer month, String category) {
+        if (year == null) {year = LocalDate.now().getYear();}
+        if (month == null) {month = LocalDate.now().getMonthValue();}
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDateTime start = LocalDateTime.of(year,month,1,0,0);
+        LocalDateTime end = LocalDateTime.of(year,month, yearMonth.lengthOfMonth(), 23,59,59);
+        List<LocalDateTime> dayList = null;
+        if(category == null){
+            dayList = reviewRepository.findAllCreatedAtByDate(user, start, end);
+        }
+        else {
+            Category cat = Category.valueOf(category);
+            dayList = reviewRepository.findAllCreatedAtByDateAndCategory(user, start, end, cat);
+        }
+        return UserConverter.toVisitCalendarDTO(dayList);
+    }
 }

--- a/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
+++ b/src/main/java/com/example/locavel/web/controller/PlaceRestController.java
@@ -162,14 +162,14 @@ public class PlaceRestController {
             @Parameter(name = "category", description = "food/spot/activity 중 입력해주세요."),
             @Parameter(name = "region", description = "my(내지역)/interest(관심지역)/etc(그외) 중 입력해주세요.")
     })
-    public ApiResponse<PlaceResponseDTO.WishPlaceListDTO> getWishList(
+    public ApiResponse<PlaceResponseDTO.PlacePreviewListDTO> getWishList(
             HttpServletRequest httpServletRequest,
             @RequestParam(name = "page") Integer page,
             @RequestParam(name = "category") String category,
             @RequestParam(name = "region") String region) {
         User user = userCommandService.getUser(httpServletRequest);
-        PlaceResponseDTO.WishPlaceListDTO response = placeService.getWishPlaceList(user, category, region,  page-1);
-        response.getWishPlaceDTOList().stream().map(wishPlaceDTO -> placeService.setPlaceImg(wishPlaceDTO)).collect(Collectors.toList());
+        PlaceResponseDTO.PlacePreviewListDTO response = placeService.getWishPlaceList(user, category, region,  page-1);
+        response.getPlacePreviewDTOList().stream().map(placePreviewDTO -> placeService.setPlaceImg(placePreviewDTO)).collect(Collectors.toList());
         return ApiResponse.of(SuccessStatus.WISHLIST_GET_OK,response);
     }
 }

--- a/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceResponseDTO.java
+++ b/src/main/java/com/example/locavel/web/dto/PlaceDTO/PlaceResponseDTO.java
@@ -100,8 +100,8 @@ public class PlaceResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class WishPlaceListDTO {
-        List<WishPlaceDTO> wishPlaceDTOList;
+    public static class PlacePreviewListDTO {
+        List<PlacePreviewDTO> PlacePreviewDTOList;
         Integer listSize;
         Integer totalPage;
         Long totalElements;
@@ -113,7 +113,7 @@ public class PlaceResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Setter
-    public static class WishPlaceDTO {
+    public static class PlacePreviewDTO {
         Long placeId;
         String name;
         String placeImg;

--- a/src/main/java/com/example/locavel/web/dto/UserDTO/UserResponseDto.java
+++ b/src/main/java/com/example/locavel/web/dto/UserDTO/UserResponseDto.java
@@ -4,9 +4,10 @@ import com.example.locavel.domain.enums.Grade;
 import com.example.locavel.domain.enums.Role;
 import com.example.locavel.domain.enums.SocialType;
 import lombok.*;
-import org.springframework.cglib.core.Local;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class UserResponseDto {
 
@@ -70,5 +71,27 @@ public class UserResponseDto {
         private Grade localGrade;
         private Grade travelerGrade;
     }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserProfileDTO {
+        private Long userId;
+        private String nickname;
+        private Grade localGrade;
+        private Grade travelerGrade;
+        private String imgUrl;
+        private Integer reviewCount;
+        private Integer follower;
+        private Integer following;
+        private String introduce;
+    }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VisitCalendarDTO {
+        List<LocalDate> visitDayList;
+    }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- #56 

### 💻 작업 내용
- 마이페이지 프로필 조회 API를 구현했습니다.
- 마이페이지 방문한 곳 조회 API를 구현했습니다. 리뷰를 달았으면 방문한 것으로 판단했습니다.
- 마이페이지의 기록 조회 API를 구현했습니다. 쿼리 스트링으로 조회할 연도와 달을 입력받아 해당 달의 리뷰를 단 날짜들을 응답합니다. 또한 food/spot/activity별 조회도 가능합니다. 쿼리 스트링으로 연도 혹은 달을 입력하지 않으면 오늘 날짜의 연도와 달을 기준으로 조회하며, 카테고리를 입력하지 않으면 전체조회를 합니다. 
- User 엔티티에 reviewCount를 추가했습니다. 장소를 등록하거나, 리뷰를 등록하거나, 리뷰를 삭제하면 자동으로 반영됩니다. 