### PR TITLE
fix : 내 지역 설정 필수 에러 메시지 추가

### DIFF
--- a/src/main/java/com/example/locavel/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/locavel/apiPayload/code/status/ErrorStatus.java
@@ -41,6 +41,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //유저
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001","해당 유저가 존재하지 않습니다."),
     USER_SAME(HttpStatus.BAD_REQUEST,"USER4002","본인입니다."),
+    USER_REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4003", "내 지역 설정은 필수 입니다. 설정 후 다시 시도해주세요."),
 
     //팔로우
     FOLLOWING_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW4001","팔로우 중이 아닙니다."),

--- a/src/main/java/com/example/locavel/domain/enums/Traveler.java
+++ b/src/main/java/com/example/locavel/domain/enums/Traveler.java
@@ -1,5 +1,7 @@
 package com.example.locavel.domain.enums;
 
+import com.example.locavel.apiPayload.code.status.ErrorStatus;
+import com.example.locavel.apiPayload.exception.handler.UserHandler;
 import com.example.locavel.domain.Places;
 import com.example.locavel.domain.User;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -15,12 +17,17 @@ public enum Traveler {
 
     // 유저의 현지인/여행객 판단
     public static Traveler of(Places place, User user) {
-        Long userRegion = user.getMy_area().getId();
-        Long placeRegion = place.getRegion().getId();
-        if (userRegion == placeRegion || userRegion.equals(placeRegion)) {
-            return NO; // 현지인
+        if(user.getMy_area() == null) {
+            throw new UserHandler(ErrorStatus.USER_REGION_NOT_FOUND);
         }
-        else return YES; //여행객
+        else {
+            Long userRegion = user.getMy_area().getId();
+            Long placeRegion = place.getRegion().getId();
+            if (userRegion == placeRegion || userRegion.equals(placeRegion)) {
+                return NO; // 현지인
+            }
+            else return YES; //여행객
+        }
     }
     @JsonValue
     public String getViewName() {


### PR DESCRIPTION
### 관련 이슈
- #79 

### 작업 내용
- 내 지역 미설정 시 필요한 지역 설정 필수 안내 에러 메시지를 추가했습니다.

장소 등록, 리뷰 등록시 내 지역이 미설정되어 있으면 다음과 같은 응답을 받습니다.
```
{
  "isSuccess": false,
  "code": "USER4003",
  "message": "내 지역 설정은 필수 입니다. 설정 후 다시 시도해주세요."
}
``` 